### PR TITLE
Fix stub output keys

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,8 @@
+import os
 import types, pytest, asyncio
+
+# Provide a fake API key so OpenAI client initialization succeeds during import
+os.environ.setdefault("OPENAI_API_KEY", "sk-test")
 
 @pytest.fixture(autouse=True)
 def patch_graph(monkeypatch):
@@ -14,12 +18,21 @@ def patch_graph(monkeypatch):
         await asyncio.sleep(0)   # laisse la boucle tourner
 
     def fake_invoke(state):
+        """Return a structure similar to ``graph.invoke`` output."""
+        summary = "Exécution réussie ✅"
         return {
             "render": {
-                "html": "<p>stub</p>",
-                "summary": "ok",
+                "html": "<p>todo stub</p>",
+                "summary": summary,
                 "artifacts": []
-            }
+            },
+            "result": summary,
+            "exec_result": {
+                "success": True,
+                "stdout": "stub\n",
+                "stderr": "",
+                "artifacts": []
+            },
         }
 
     FakeGraph = types.SimpleNamespace(invoke=fake_invoke, astream=fake_astream)


### PR DESCRIPTION
## Summary
- expand test stub to match core loop output
- add fake OPENAI_API_KEY for imports

## Testing
- `pytest tests/test_core_loop.py tests/test_e2e.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687b53a6ffec833099ea63d937ad6d00