### PR TITLE
Improve project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,50 @@
 
 MVP agentique sur Raspberry Pi.
 
+## Installation
+
+1. Installez [Poetry](https://python-poetry.org/) puis récupérez les dépendances :
+
+```bash
+pip install poetry
+poetry install --with dev
+```
+
+2. Configurez vos variables d'environnement (ou créez un fichier `.env`) :
+
+```bash
+export OPENAI_API_KEY=<votre-clé-OpenAI>
+```
+
+## Lancement de l'API FastAPI
+
+```bash
+poetry run uvicorn api.main:app --reload
+```
+
+## Frontend Next.js
+
+```bash
+cd frontend
+npm install    # ou pnpm install
+npm run dev
+```
+
+L'application sera alors disponible sur `http://localhost:3000`.
+
+## Ligne de commande
+
+Vous pouvez exécuter la boucle principale sans serveur :
+
+```bash
+poetry run python orchestrator/core_loop.py "Votre objectif"
+```
+
+## Tests
+
+L'ensemble de la suite de tests se lance avec :
+
+```bash
+poetry run pytest
+```
+


### PR DESCRIPTION
## Summary
- add install steps using Poetry
- document API and frontend startup commands
- describe environment variables and CLI usage
- add instructions for running tests

## Testing
- `poetry run pytest -q` *(fails: OpenAI API key not set)*

------
https://chatgpt.com/codex/tasks/task_e_687b553cb2248330994fe735d2523773