### PR TITLE
Add root .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Python cache and virtual env
+__pycache__/
+*.py[cod]
+*.egg-info/
+dist/
+build/
+.venv/
+.env
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+.tox/
+
+# Node modules and build artifacts
+node_modules/
+.pnpm/
+.yarn/
+.npm/
+.next/
+coverage/
+coverage.xml
+
+# Misc tools
+.DS_Store
+.idea/
+.vscode/
+


### PR DESCRIPTION
## Summary
- add `.gitignore` at repository root for Python, Node and common tool caches

## Testing
- `pytest -q` *(fails: OpenAI API key missing)*

------
https://chatgpt.com/codex/tasks/task_e_687b5541416883309631b091786e3253