### PR TITLE
Fix failing tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,3 +38,10 @@ def patch_graph(monkeypatch):
 
     FakeGraph = types.SimpleNamespace(invoke=fake_invoke, astream=fake_astream)
     monkeypatch.setattr(cl, "graph", FakeGraph)
+
+    # Also patch the graph imported in the API module
+    import api.main as main
+    monkeypatch.setattr(main, "graph", FakeGraph)
+
+    import api.ws as ws
+    monkeypatch.setattr(ws, "graph", FakeGraph)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,9 +1,10 @@
 import pytest
-from httpx import AsyncClient, ASGITransport
+from httpx import AsyncClient
 from httpx_ws import aconnect_ws
+from httpx_ws.transport import ASGIWebSocketTransport
 from api.main import app
 
-transport = ASGITransport(app=app)
+transport = ASGIWebSocketTransport(app=app)
 BASE_URL = "http://test"
 
 @pytest.mark.asyncio
@@ -24,7 +25,7 @@ async def test_chat_endpoint():
 @pytest.mark.asyncio
 async def test_ws_stream():
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        async with aconnect_ws(f"{BASE_URL}/ws", ac) as ws:
+        async with aconnect_ws("http://test/stream", ac) as ws:
             await ws.send_json({"objective": "demo"})
             chunk = await ws.receive_json()
             # Le stub renvoie un chunk 'plan'

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,9 +1,26 @@
 # tests/test_planner.py
-from agents.planner import make_plan
+from agents import planner as pl
 from agents.schemas import Plan
+import types
+import json
+import pytest
 
-def test_make_plan():
-    plan = make_plan("Construire une todo-app React")
+@pytest.mark.usefixtures("patch_graph")
+def test_make_plan(monkeypatch):
+    def fake_invoke(messages):
+        json_plan = {
+            "objective": "Construire une todo-app React",
+            "steps": [
+                {"id": 1, "title": "Step 1", "description": "desc", "depends_on": []},
+                {"id": 2, "title": "Step 2", "description": "desc", "depends_on": [1]},
+                {"id": 3, "title": "Step 3", "description": "desc", "depends_on": [2]},
+            ],
+        }
+        return types.SimpleNamespace(content=json.dumps(json_plan))
+
+    monkeypatch.setattr(pl.ChatOpenAI, "invoke", lambda self, messages: fake_invoke(messages))
+
+    plan = pl.make_plan("Construire une todo-app React")
     assert isinstance(plan, Plan)
     assert 3 <= len(plan.steps) <= 6
     ids = [s.id for s in plan.steps]


### PR DESCRIPTION
## Summary
- update WebSocket tests to use httpx_ws with ASGIWebSocketTransport
- stub planner ChatOpenAI in tests
- ensure API and WS routers use fake graph during testing

## Testing
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_687b9f840be08330ab035f73a379472f