### PR TITLE
Add Item model and CRUD

### DIFF
--- a/orchestrator/core_loop.py
+++ b/orchestrator/core_loop.py
@@ -10,8 +10,6 @@ from langchain_openai import ChatOpenAI
 from langgraph.graph import StateGraph, END
 
 from agents.planner import make_plan
-from agents.executor import run_python
-from agents.writer import render_exec
 from agents.schemas import ExecResult, Plan
 import threading
 
@@ -87,7 +85,7 @@ def writer(state: LoopState) -> dict:
         f"<h2>Résultat : {state.objective}</h2>\n"
         f"<pre><code>{er.stdout.strip()}</code></pre>"
     )
-    lines = [l.strip() for l in er.stdout.splitlines() if l.strip()]
+    lines = [line.strip() for line in er.stdout.splitlines() if line.strip()]
     summary = lines[-1] if lines else er.stdout.strip()
 
     render = {"html": html, "summary": summary, "artifacts": []}

--- a/orchestrator/crud.py
+++ b/orchestrator/crud.py
@@ -1,7 +1,13 @@
 # orchestrator/crud.py
 import sqlite3
+import json
 from typing import List, Optional
-from .models import Project, ProjectCreate
+from .models import (
+    Project,
+    ProjectCreate,
+    Item,
+    ItemCreate,
+)
 
 DATABASE_URL = "orchestrator.db"
 
@@ -17,6 +23,29 @@ def init_db():
         "id INTEGER PRIMARY KEY AUTOINCREMENT,"
         "name TEXT NOT NULL,"
         "description TEXT"
+        ")"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS items ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "project_id INTEGER NOT NULL,"
+        "type TEXT NOT NULL,"
+        "title TEXT NOT NULL,"
+        "description TEXT,"
+        "status TEXT NOT NULL,"
+        "parent_id INTEGER,"
+        "acceptance_criteria TEXT,"
+        "created_at TEXT DEFAULT CURRENT_TIMESTAMP,"
+        "updated_at TEXT DEFAULT CURRENT_TIMESTAMP,"
+        "FOREIGN KEY(parent_id) REFERENCES items(id),"
+        "FOREIGN KEY(project_id) REFERENCES projects(id)"
+        ")"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS test_cases ("
+        "item_id INTEGER PRIMARY KEY,"
+        "expected_result TEXT,"
+        "FOREIGN KEY(item_id) REFERENCES items(id) ON DELETE CASCADE"
         ")"
     )
     conn.close()
@@ -71,3 +100,86 @@ def delete_project(project_id: int) -> bool:
     conn.commit()
     conn.close()
     return cursor.rowcount > 0
+
+
+# ----- Item CRUD -----
+
+HIERARCHY = {
+    "Epic": None,
+    "Feature": "Epic",
+    "US": "Feature",
+    "UC": "US",
+    "TC": "UC",
+}
+
+
+def _get_item(cursor, item_id: int) -> Optional[Item]:
+    cursor.execute("SELECT * FROM items WHERE id = ?", (item_id,))
+    row = cursor.fetchone()
+    if not row:
+        return None
+    item = Item(**dict(row))
+    cursor.execute(
+        "SELECT expected_result FROM test_cases WHERE item_id = ?",
+        (item_id,),
+    )
+    tc = cursor.fetchone()
+    if tc:
+        item.expected_result = tc["expected_result"]
+    return item
+
+
+def create_item(item: ItemCreate) -> Item:
+    if item.type not in HIERARCHY:
+        raise ValueError("invalid item type")
+    if item.type != "Epic" and item.parent_id is None:
+        raise ValueError("parent_id required for non-Epic items")
+
+    conn = get_db_connection()
+    cur = conn.cursor()
+
+    if item.parent_id is not None:
+        parent = _get_item(cur, item.parent_id)
+        if not parent:
+            conn.close()
+            raise ValueError("parent not found")
+        expected_parent_type = HIERARCHY[item.type]
+        if parent.type != expected_parent_type:
+            conn.close()
+            raise ValueError("invalid parent type")
+
+    cur.execute(
+        """
+        INSERT INTO items (project_id, type, title, description, status, parent_id, acceptance_criteria)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            item.project_id,
+            item.type,
+            item.title,
+            item.description,
+            item.status,
+            item.parent_id,
+            json.dumps(item.acceptance_criteria) if item.acceptance_criteria else None,
+        ),
+    )
+    item_id = cur.lastrowid
+
+    if item.type == "TC" and item.expected_result is not None:
+        cur.execute(
+            "INSERT INTO test_cases (item_id, expected_result) VALUES (?, ?)",
+            (item_id, item.expected_result),
+        )
+
+    conn.commit()
+    created = _get_item(cur, item_id)
+    conn.close()
+    return created
+
+
+def get_item(item_id: int) -> Optional[Item]:
+    conn = get_db_connection()
+    cur = conn.cursor()
+    item = _get_item(cur, item_id)
+    conn.close()
+    return item

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -9,3 +9,26 @@ class Project(BaseModel):
 class ProjectCreate(BaseModel):
     name: str
     description: str | None = None
+
+
+# ----- Item models -----
+
+class ItemBase(BaseModel):
+    project_id: int
+    type: str
+    title: str
+    description: str | None = None
+    status: str
+    parent_id: int | None = None
+    acceptance_criteria: dict | None = None
+
+
+class ItemCreate(ItemBase):
+    expected_result: str | None = None
+
+
+class Item(ItemBase):
+    id: int
+    created_at: str
+    updated_at: str
+    expected_result: str | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
-import os
-import types, pytest, asyncio
+import types
+import pytest
+import asyncio
 
 
 # Provide a fake API key so OpenAI client initialization succeeds during import


### PR DESCRIPTION
## Summary
- support new `Item` entities with extra fields
- store test case details separately
- fix linter issues

## Testing
- `poetry run ruff check .`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fadeb4efc8330bff5f24a16a2ff5c