### PR TITLE
Implement hierarchical items API

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -2,8 +2,12 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from api.ws import router as ws_router
 from orchestrator.core_loop import graph, LoopState, Memory
+from orchestrator import crud
+from orchestrator.models import Item, ItemCreate, ItemUpdate
+from fastapi import HTTPException, Query
 
 app = FastAPI()
+crud.init_db()
 
 origins = [
     "http://localhost:3000",
@@ -31,3 +35,70 @@ async def chat(payload: dict):
     state = LoopState(objective=objective, mem_obj=Memory())
     final = graph.invoke(state)
     return final["render"]  # html + summary
+
+
+# -------------------- Items --------------------
+
+@app.get("/items", response_model=list[Item])
+async def list_items(
+    project_id: int = Query(...),
+    type: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+):
+    return crud.get_items(project_id=project_id, type=type, limit=limit, offset=offset)
+
+
+@app.post("/items", response_model=Item, status_code=201)
+async def create_item(item: ItemCreate):
+    if item.parent_id is not None:
+        parent = crud.get_item(item.parent_id)
+        if not parent or parent.project_id != item.project_id:
+            raise HTTPException(status_code=400, detail="invalid parent_id")
+        if parent.type != "folder":
+            raise HTTPException(status_code=400, detail="parent must be folder")
+    return crud.create_item(item)
+
+
+@app.get("/items/{item_id}", response_model=Item)
+async def read_item(item_id: int, project_id: int | None = Query(None)):
+    item = crud.get_item(item_id)
+    if not item:
+        raise HTTPException(status_code=404)
+    if project_id is not None and item.project_id != project_id:
+        raise HTTPException(status_code=404)
+    return item
+
+
+@app.patch("/items/{item_id}", response_model=Item)
+async def update_item(item_id: int, payload: ItemUpdate):
+    item = crud.get_item(item_id)
+    if not item:
+        raise HTTPException(status_code=404)
+    data = payload.model_dump(exclude_unset=True)
+    if "parent_id" in data and data["parent_id"] is not None:
+        new_parent = crud.get_item(data["parent_id"])
+        if not new_parent or new_parent.project_id != item.project_id:
+            raise HTTPException(status_code=400, detail="invalid parent_id")
+        if new_parent.type != "folder" or new_parent.id == item_id:
+            raise HTTPException(status_code=400, detail="invalid hierarchy")
+        # check not moving under its descendant
+        current = new_parent
+        while current.parent_id is not None:
+            if current.parent_id == item_id:
+                raise HTTPException(status_code=400, detail="cycle detected")
+            current = crud.get_item(current.parent_id)
+            if current is None:
+                break
+    return crud.update_item(item_id, ItemUpdate(**data))
+
+
+@app.delete("/items/{item_id}", status_code=204)
+async def delete_item(item_id: int):
+    item = crud.get_item(item_id)
+    if not item:
+        raise HTTPException(status_code=404)
+    if crud.item_has_children(item_id):
+        raise HTTPException(status_code=400, detail="item has children")
+    crud.delete_item(item_id)
+    return None

--- a/orchestrator/crud.py
+++ b/orchestrator/crud.py
@@ -1,7 +1,7 @@
 # orchestrator/crud.py
 import sqlite3
 from typing import List, Optional
-from .models import Project, ProjectCreate
+from .models import Project, ProjectCreate, Item, ItemCreate, ItemUpdate
 
 DATABASE_URL = "orchestrator.db"
 
@@ -17,6 +17,17 @@ def init_db():
         "id INTEGER PRIMARY KEY AUTOINCREMENT,"
         "name TEXT NOT NULL,"
         "description TEXT"
+        ")"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS items ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "project_id INTEGER NOT NULL,"
+        "title TEXT NOT NULL,"
+        "type TEXT NOT NULL,"
+        "parent_id INTEGER,"
+        "FOREIGN KEY(project_id) REFERENCES projects(id),"
+        "FOREIGN KEY(parent_id) REFERENCES items(id)"
         ")"
     )
     conn.close()
@@ -71,3 +82,80 @@ def delete_project(project_id: int) -> bool:
     conn.commit()
     conn.close()
     return cursor.rowcount > 0
+
+
+# -------------------- Items --------------------
+
+def create_item(item: ItemCreate) -> Item:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO items (project_id, title, type, parent_id) VALUES (?, ?, ?, ?)",
+        (item.project_id, item.title, item.type, item.parent_id),
+    )
+    conn.commit()
+    item_id = cursor.lastrowid
+    conn.close()
+    return Item(id=item_id, **item.model_dump())
+
+
+def get_item(item_id: int) -> Optional[Item]:
+    conn = get_db_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM items WHERE id = ?", (item_id,))
+    row = cur.fetchone()
+    conn.close()
+    return Item(**dict(row)) if row else None
+
+
+def get_items(project_id: int, type: str | None = None, limit: int = 50, offset: int = 0) -> List[Item]:
+    conn = get_db_connection()
+    cur = conn.cursor()
+    if type:
+        cur.execute(
+            "SELECT * FROM items WHERE project_id = ? AND type = ? ORDER BY id LIMIT ? OFFSET ?",
+            (project_id, type, limit, offset),
+        )
+    else:
+        cur.execute(
+            "SELECT * FROM items WHERE project_id = ? ORDER BY id LIMIT ? OFFSET ?",
+            (project_id, limit, offset),
+        )
+    rows = cur.fetchall()
+    conn.close()
+    return [Item(**dict(r)) for r in rows]
+
+
+def update_item(item_id: int, data: ItemUpdate) -> Optional[Item]:
+    fields = []
+    values = []
+    for field, value in data.model_dump(exclude_none=True).items():
+        fields.append(f"{field} = ?")
+        values.append(value)
+    if not fields:
+        return get_item(item_id)
+    values.append(item_id)
+    conn = get_db_connection()
+    cur = conn.cursor()
+    cur.execute(f"UPDATE items SET {', '.join(fields)} WHERE id = ?", values)
+    conn.commit()
+    conn.close()
+    return get_item(item_id)
+
+
+def delete_item(item_id: int) -> bool:
+    conn = get_db_connection()
+    cur = conn.cursor()
+    cur.execute("DELETE FROM items WHERE id = ?", (item_id,))
+    conn.commit()
+    conn.close()
+    return cur.rowcount > 0
+
+
+def item_has_children(item_id: int) -> bool:
+    conn = get_db_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT 1 FROM items WHERE parent_id = ? LIMIT 1", (item_id,))
+    has = cur.fetchone() is not None
+    conn.close()
+    return has

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -9,3 +9,24 @@ class Project(BaseModel):
 class ProjectCreate(BaseModel):
     name: str
     description: str | None = None
+
+
+class Item(BaseModel):
+    id: int
+    project_id: int
+    title: str
+    type: str
+    parent_id: int | None = None
+
+
+class ItemCreate(BaseModel):
+    project_id: int
+    title: str
+    type: str
+    parent_id: int | None = None
+
+
+class ItemUpdate(BaseModel):
+    title: str | None = None
+    type: str | None = None
+    parent_id: int | None = None

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -1,0 +1,65 @@
+import os
+import pytest
+from httpx import AsyncClient
+from httpx_ws.transport import ASGIWebSocketTransport
+from api.main import app
+from orchestrator import crud
+from orchestrator.models import ProjectCreate
+
+transport = ASGIWebSocketTransport(app=app)
+
+@pytest.mark.asyncio
+async def test_items_crud():
+    # reset database
+    if os.path.exists(crud.DATABASE_URL):
+        os.remove(crud.DATABASE_URL)
+    crud.init_db()
+    project = crud.create_project(ProjectCreate(name="proj", description=None))
+
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        r = await ac.post("/items", json={"project_id": project.id, "title": "root", "type": "folder"})
+        assert r.status_code == 201
+        folder1 = r.json()
+
+        r = await ac.post("/items", json={"project_id": project.id, "title": "folder2", "type": "folder"})
+        folder2 = r.json()
+
+        r_task = await ac.post("/items", json={"project_id": project.id, "title": "task", "type": "task", "parent_id": folder1["id"]})
+        assert r_task.status_code == 201
+        task = r_task.json()
+
+        resp = await ac.post("/items", json={"project_id": project.id, "title": "oops", "type": "task", "parent_id": task["id"]})
+        assert resp.status_code == 400
+
+        # cannot delete folder with child
+        resp = await ac.delete(f"/items/{folder1['id']}")
+        assert resp.status_code == 400
+
+        # list items filtered
+        r = await ac.get(f"/items?project_id={project.id}&type=task")
+        assert r.status_code == 200
+        tasks = r.json()
+        assert all(it["type"] == "task" for it in tasks)
+
+        # read item with wrong project
+        other_proj = crud.create_project(ProjectCreate(name="other", description=None))
+        resp = await ac.get(f"/items/{task['id']}?project_id={other_proj.id}")
+        assert resp.status_code == 404
+
+        # move task under root -> to check patch
+        r = await ac.patch(f"/items/{task['id']}", json={"parent_id": folder2["id"]})
+        assert r.status_code == 200
+        assert r.json()["parent_id"] == folder2["id"]
+
+        # folder1 now deletable since no child after move
+        resp = await ac.delete(f"/items/{folder1['id']}")
+        assert resp.status_code == 204
+
+        # folder2 still has child -> cannot delete
+        resp = await ac.delete(f"/items/{folder2['id']}")
+        assert resp.status_code == 400
+
+        # delete child then folder2
+        await ac.delete(f"/items/{task['id']}")
+        resp = await ac.delete(f"/items/{folder2['id']}")
+        assert resp.status_code == 204


### PR DESCRIPTION
## Summary
- create new Item models
- extend CRUD with items table and operations
- expose `/items` endpoints in the FastAPI app
- test new API behaviour with async client

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb32919e883308ffb8435ae6a1dc8