### PR TITLE
Implement simple backlog management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ node_modules/
 .next/
 coverage/
 coverage.xml
+orchestrator.db
 
 # Misc tools
 .DS_Store

--- a/api/main.py
+++ b/api/main.py
@@ -2,8 +2,15 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from api.ws import router as ws_router
 from orchestrator.core_loop import graph, LoopState, Memory
+from orchestrator import crud
+from orchestrator.models import ProjectCreate, BacklogItemCreate
 
 app = FastAPI()
+
+
+@app.on_event("startup")
+def startup_event():
+    crud.init_db()
 
 origins = [
     "http://localhost:3000",
@@ -31,3 +38,46 @@ async def chat(payload: dict):
     state = LoopState(objective=objective, mem_obj=Memory())
     final = graph.invoke(state)
     return final["render"]  # html + summary
+
+
+# ---- Project endpoints ----
+@app.get("/projects")
+async def list_projects():
+    return crud.get_projects()
+
+
+@app.post("/projects")
+async def create_project(project: ProjectCreate):
+    return crud.create_project(project)
+
+
+@app.put("/projects/{project_id}")
+async def update_project(project_id: int, project: ProjectCreate):
+    return crud.update_project(project_id, project)
+
+
+@app.delete("/projects/{project_id}")
+async def delete_project(project_id: int):
+    return crud.delete_project(project_id)
+
+
+# ---- Backlog item endpoints ----
+@app.get("/projects/{project_id}/items")
+async def list_items(project_id: int):
+    return crud.get_items(project_id)
+
+
+@app.post("/projects/{project_id}/items")
+async def create_item(project_id: int, item: BacklogItemCreate):
+    item.project_id = project_id
+    return crud.create_item(item)
+
+
+@app.put("/items/{item_id}")
+async def update_item(item_id: int, item: BacklogItemCreate):
+    return crud.update_item(item_id, item)
+
+
+@app.delete("/items/{item_id}")
+async def delete_item(item_id: int):
+    return crud.delete_item(item_id)

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { ProjectProvider } from "@/context/ProjectContext";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <ProjectProvider>{children}</ProjectProvider>
       </body>
     </html>
   );

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,6 +5,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import StreamViewer from "@/components/StreamViewer";
 import HistoryPanel from "@/components/HistoryPanel";
+import BacklogPane from "@/components/BacklogPane";
+import { BacklogProvider } from "@/context/BacklogContext";
 
 export default function Home() {
   const [objective, setObjective] = useState("");
@@ -31,8 +33,9 @@ export default function Home() {
   };
 
   return (
-    <main className="flex flex-col gap-6 p-6 max-w-3xl mx-auto">
-      <h1 className="text-2xl font-bold">Orchestrator Assistant</h1>
+    <BacklogProvider>
+      <main className="flex flex-col gap-6 p-6 max-w-3xl mx-auto">
+        <h1 className="text-2xl font-bold">Orchestrator Assistant</h1>
 
       <form
         onSubmit={e => {
@@ -51,7 +54,10 @@ export default function Home() {
 
       <StreamViewer ref={viewerRef} />
 
-      <HistoryPanel history={history} />
-    </main>
+        <BacklogPane />
+
+        <HistoryPanel history={history} />
+      </main>
+    </BacklogProvider>
   );
 }

--- a/frontend/src/components/BacklogPane.tsx
+++ b/frontend/src/components/BacklogPane.tsx
@@ -1,0 +1,58 @@
+"use client";
+import { useState } from 'react';
+import { useBacklog } from '@/context/BacklogContext';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { useProjects } from '@/context/ProjectContext';
+
+export default function BacklogPane() {
+  const { items, createItem } = useBacklog();
+  const { currentProject } = useProjects();
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState('');
+  const [type, setType] = useState('Epic');
+
+  const disabled = !currentProject;
+
+  const handleCreate = async () => {
+    await createItem({ title, type, description: '', parent_id: null, project_id: currentProject!.id });
+    setTitle('');
+    setOpen(false);
+  };
+
+  const renderItems = (parent: number | null, depth = 0) =>
+    items
+      .filter((i) => i.parent_id === parent)
+      .map((i) => (
+        <div key={i.id} style={{ marginLeft: depth * 16 }} className="flex items-center gap-2 py-1">
+          <span>{i.type === 'Epic' ? '📦' : '📝'}</span>
+          <span>{i.title}</span>
+        </div>
+      ));
+
+  return (
+    <div className="p-4 border rounded-md bg-gray-50">
+      <div className="flex justify-between items-center mb-2">
+        <h3 className="font-medium">Backlog</h3>
+        <Button size="sm" onClick={() => setOpen(true)} disabled={disabled}>
+          +
+        </Button>
+      </div>
+      <div>{renderItems(null)}</div>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Nouvel item</DialogTitle>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            <Input placeholder="Titre" value={title} onChange={(e) => setTitle(e.target.value)} />
+          </div>
+          <DialogFooter>
+            <Button onClick={handleCreate}>Créer</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/src/context/BacklogContext.tsx
+++ b/frontend/src/context/BacklogContext.tsx
@@ -1,0 +1,105 @@
+"use client";
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { BacklogItem } from '@/models/backlogItem';
+import { useProjects } from '@/context/ProjectContext';
+
+interface BacklogContextType {
+  items: BacklogItem[];
+  isLoading: boolean;
+  createItem: (item: Omit<BacklogItem, 'id'>) => Promise<BacklogItem | null>;
+  updateItem: (id: number, item: Omit<BacklogItem, 'id'>) => Promise<BacklogItem | null>;
+  deleteItem: (id: number) => Promise<boolean>;
+  refreshItems: () => Promise<void>;
+}
+
+const BacklogContext = createContext<BacklogContextType | undefined>(undefined);
+
+export const BacklogProvider = ({ children }: { children: ReactNode }) => {
+  const { currentProject } = useProjects();
+  const [items, setItems] = useState<BacklogItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || '';
+
+  const fetchItems = async () => {
+    if (!currentProject) {
+      setItems([]);
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const res = await fetch(`${apiUrl}/projects/${currentProject.id}/items`);
+      const data = await res.json();
+      setItems(data);
+    } catch (err) {
+      console.error('Failed to fetch backlog items:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const createItem = async (item: Omit<BacklogItem, 'id'>) => {
+    if (!currentProject) return null;
+    try {
+      const res = await fetch(`${apiUrl}/projects/${currentProject.id}/items`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(item),
+      });
+      if (!res.ok) throw new Error('Failed');
+      const newItem = await res.json();
+      await fetchItems();
+      return newItem;
+    } catch (err) {
+      console.error('Create item error', err);
+      return null;
+    }
+  };
+
+  const updateItem = async (id: number, item: Omit<BacklogItem, 'id'>) => {
+    try {
+      const res = await fetch(`${apiUrl}/items/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(item),
+      });
+      if (!res.ok) throw new Error('Failed');
+      const up = await res.json();
+      await fetchItems();
+      return up;
+    } catch (err) {
+      console.error('Update item error', err);
+      return null;
+    }
+  };
+
+  const deleteItem = async (id: number) => {
+    try {
+      const res = await fetch(`${apiUrl}/items/${id}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error('Failed');
+      await fetchItems();
+      return true;
+    } catch (err) {
+      console.error('Delete item error', err);
+      return false;
+    }
+  };
+
+  useEffect(() => {
+    fetchItems();
+  }, [currentProject]);
+
+  const refreshItems = fetchItems;
+
+  return (
+    <BacklogContext.Provider value={{ items, isLoading, createItem, updateItem, deleteItem, refreshItems }}>
+      {children}
+    </BacklogContext.Provider>
+  );
+};
+
+export const useBacklog = () => {
+  const ctx = useContext(BacklogContext);
+  if (!ctx) throw new Error('useBacklog must be used within BacklogProvider');
+  return ctx;
+};
+

--- a/frontend/src/models/backlogItem.ts
+++ b/frontend/src/models/backlogItem.ts
@@ -1,0 +1,8 @@
+export interface BacklogItem {
+  id: number;
+  title: string;
+  description: string | null;
+  type: string;
+  project_id: number;
+  parent_id: number | null;
+}

--- a/orchestrator/crud.py
+++ b/orchestrator/crud.py
@@ -1,7 +1,12 @@
 # orchestrator/crud.py
 import sqlite3
 from typing import List, Optional
-from .models import Project, ProjectCreate
+from .models import (
+    Project,
+    ProjectCreate,
+    BacklogItem,
+    BacklogItemCreate,
+)
 
 DATABASE_URL = "orchestrator.db"
 
@@ -17,6 +22,18 @@ def init_db():
         "id INTEGER PRIMARY KEY AUTOINCREMENT,"
         "name TEXT NOT NULL,"
         "description TEXT"
+        ")"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS backlog ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "project_id INTEGER NOT NULL,"
+        "parent_id INTEGER,"
+        "title TEXT NOT NULL,"
+        "description TEXT,"
+        "type TEXT NOT NULL,"
+        "FOREIGN KEY(project_id) REFERENCES projects(id),"
+        "FOREIGN KEY(parent_id) REFERENCES backlog(id)"
         ")"
     )
     conn.close()
@@ -71,3 +88,76 @@ def delete_project(project_id: int) -> bool:
     conn.commit()
     conn.close()
     return cursor.rowcount > 0
+
+
+def create_item(item: BacklogItemCreate) -> BacklogItem:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO backlog (project_id, parent_id, title, description, type) VALUES (?, ?, ?, ?, ?)",
+        (
+            item.project_id,
+            item.parent_id,
+            item.title,
+            item.description,
+            item.type,
+        ),
+    )
+    conn.commit()
+    item_id = cursor.lastrowid
+    conn.close()
+    return BacklogItem(id=item_id, **item.model_dump())
+
+
+def get_item(item_id: int) -> Optional[BacklogItem]:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    cursor.execute("SELECT * FROM backlog WHERE id = ?", (item_id,))
+    row = cursor.fetchone()
+    conn.close()
+    if row:
+        return BacklogItem(**dict(row))
+    return None
+
+
+def get_items(project_id: int) -> List[BacklogItem]:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT * FROM backlog WHERE project_id = ? ORDER BY id",
+        (project_id,),
+    )
+    rows = cursor.fetchall()
+    conn.close()
+    return [BacklogItem(**dict(row)) for row in rows]
+
+
+def update_item(item_id: int, item: BacklogItemCreate) -> Optional[BacklogItem]:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    cursor.execute(
+        "UPDATE backlog SET project_id = ?, parent_id = ?, title = ?, description = ?, type = ? WHERE id = ?",
+        (
+            item.project_id,
+            item.parent_id,
+            item.title,
+            item.description,
+            item.type,
+            item_id,
+        ),
+    )
+    conn.commit()
+    conn.close()
+    if cursor.rowcount > 0:
+        return BacklogItem(id=item_id, **item.model_dump())
+    return None
+
+
+def delete_item(item_id: int) -> bool:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    cursor.execute("DELETE FROM backlog WHERE id = ?", (item_id,))
+    conn.commit()
+    conn.close()
+    return cursor.rowcount > 0
+

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -9,3 +9,20 @@ class Project(BaseModel):
 class ProjectCreate(BaseModel):
     name: str
     description: str | None = None
+
+
+class BacklogItemBase(BaseModel):
+    title: str
+    description: str | None = None
+    type: str
+    project_id: int
+    parent_id: int | None = None
+
+
+class BacklogItemCreate(BacklogItemBase):
+    pass
+
+
+class BacklogItem(BacklogItemBase):
+    id: int
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,6 +3,9 @@ from httpx import AsyncClient
 from httpx_ws import aconnect_ws
 from httpx_ws.transport import ASGIWebSocketTransport
 from api.main import app
+from orchestrator import crud
+
+crud.init_db()
 
 transport = ASGIWebSocketTransport(app=app)
 BASE_URL = "http://test"
@@ -30,3 +33,29 @@ async def test_ws_stream():
             chunk = await ws.receive_json()
             # Le stub renvoie un chunk 'plan'
             assert "plan" in chunk
+
+
+@pytest.mark.asyncio
+async def test_project_and_backlog_endpoints():
+    async with AsyncClient(transport=transport, base_url=BASE_URL) as ac:
+        # create project
+        r = await ac.post("/projects", json={"name": "Test", "description": ""})
+        assert r.status_code == 200
+        project = r.json()
+        # create item
+        item_payload = {
+            "title": "Epic 1",
+            "description": "desc",
+            "type": "Epic",
+            "project_id": project["id"],
+            "parent_id": None,
+        }
+        r2 = await ac.post(f"/projects/{project['id']}/items", json=item_payload)
+        assert r2.status_code == 200
+        item = r2.json()
+        # fetch items
+        r3 = await ac.get(f"/projects/{project['id']}/items")
+        assert r3.status_code == 200
+        items = r3.json()
+        assert len(items) == 1 and items[0]["id"] == item["id"]
+


### PR DESCRIPTION
## Summary
- add backlog item models and CRUD functions
- expose project and backlog API routes
- create Backlog context and pane in Next.js app
- integrate backlog features in the frontend
- include tests for project/item endpoints

## Testing
- `poetry run pytest -q`
- `poetry run ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68807d9a4a588330bebbb59e27965c19