### PR TITLE
feat: project-aware items

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,9 +1,14 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from api.ws import router as ws_router
 from orchestrator.core_loop import graph, LoopState, Memory
+from orchestrator import crud, models
 
 app = FastAPI()
+
+@app.on_event("startup")
+def startup():
+    crud.init_db()
 
 origins = [
     "http://localhost:3000",
@@ -28,6 +33,58 @@ async def ping():
 @app.post("/chat")
 async def chat(payload: dict):
     objective = payload.get("objective", "")
-    state = LoopState(objective=objective, mem_obj=Memory())
+    project_id = payload.get("project_id")
+    if project_id is None:
+        raise HTTPException(status_code=400, detail="project_id required")
+    state = LoopState(objective=objective, mem_obj=Memory(project_id))
     final = graph.invoke(state)
     return final["render"]  # html + summary
+
+
+@app.get("/projects")
+async def list_projects():
+    return crud.get_projects()
+
+
+@app.post("/projects")
+async def create_project(project: models.ProjectCreate):
+    return crud.create_project(project)
+
+
+@app.get("/projects/{project_id}")
+async def get_project(project_id: int):
+    project = crud.get_project(project_id)
+    if not project:
+        raise HTTPException(status_code=404)
+    return project
+
+
+@app.put("/projects/{project_id}")
+async def update_project(project_id: int, project: models.ProjectCreate):
+    updated = crud.update_project(project_id, project)
+    if not updated:
+        raise HTTPException(status_code=404)
+    return updated
+
+
+@app.delete("/projects/{project_id}")
+async def delete_project(project_id: int):
+    if not crud.delete_project(project_id):
+        raise HTTPException(status_code=404)
+    return {"status": "deleted"}
+
+
+@app.get("/items")
+async def list_items(project_id: int, limit: int = 10):
+    mem = Memory(project_id)
+    items = mem.fetch(limit)
+    return [{"role": r, "content": c} for r, c in items]
+
+
+@app.get("/items/{item_id}")
+async def get_item(item_id: int, project_id: int):
+    mem = Memory(project_id)
+    item = mem.fetch_item(item_id)
+    if not item:
+        raise HTTPException(status_code=404)
+    return item

--- a/api/ws.py
+++ b/api/ws.py
@@ -12,9 +12,13 @@ async def stream_chat(ws: WebSocket):
         # 1) Attend le 1er message JSON : {"objective": "..."}
         payload = await ws.receive_json()
         objective = payload.get("objective", "")
+        project_id = payload.get("project_id")
+        if project_id is None:
+            await ws.close(code=1008, reason="project_id required")
+            return
 
         # 2) Prépare l’état initial
-        state = LoopState(objective=objective, mem_obj=Memory())
+        state = LoopState(objective=objective, mem_obj=Memory(project_id))
 
         # 3) Stream LangGraph
         async for chunk in graph.astream(state):

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { ProjectProvider } from "@/context/ProjectContext";
+import ProjectSelector from "@/components/ProjectSelector";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -24,10 +26,13 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <ProjectProvider>
+          <div className="p-4 border-b">
+            <ProjectSelector />
+          </div>
+          {children}
+        </ProjectProvider>
       </body>
     </html>
   );

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -1,11 +1,11 @@
-export function connectWS(objective: string) {
+export function connectWS(objective: string, projectId: number) {
   const wsUrl = (process.env.NEXT_PUBLIC_API_URL || "ws://localhost:8000").replace(
     /^http/,
     "ws"
   );
   const ws = new WebSocket(`${wsUrl}/stream`);
   ws.addEventListener("open", () => {
-    ws.send(JSON.stringify({ objective }));
+    ws.send(JSON.stringify({ objective, project_id: projectId }));
   });
   return ws;
 }

--- a/orchestrator/crud.py
+++ b/orchestrator/crud.py
@@ -1,12 +1,14 @@
 # orchestrator/crud.py
 import sqlite3
+import os
 from typing import List, Optional
 from .models import Project, ProjectCreate
 
 DATABASE_URL = "orchestrator.db"
 
 def get_db_connection():
-    conn = sqlite3.connect(DATABASE_URL)
+    db_url = os.environ.get("ORCH_DB_URL", DATABASE_URL)
+    conn = sqlite3.connect(db_url)
     conn.row_factory = sqlite3.Row
     return conn
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 import os
-import types, pytest, asyncio
+import types, pytest, asyncio, tempfile
 
 
 # Provide a fake API key so OpenAI client initialization succeeds during import
-#os.environ.setdefault("OPENAI_API_KEY", "sk-test")
+os.environ.setdefault("OPENAI_API_KEY", "sk-test")
 
 @pytest.fixture(autouse=True)
 def patch_graph(monkeypatch):
@@ -13,6 +13,13 @@ def patch_graph(monkeypatch):
     - astream(...) → yield un seul chunk {"plan": {...}}
     """
     import orchestrator.core_loop as cl
+
+    # Isolated DB for tests
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    os.environ["ORCH_DB_URL"] = tmp.name
+    tmp.close()
+    from orchestrator import crud
+    crud.init_db()
 
     async def fake_astream(state):
         yield {"plan": {"plan": {"objective": state.objective}}}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,7 +17,7 @@ async def test_ping():
 @pytest.mark.asyncio
 async def test_chat_endpoint():
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        r = await ac.post("/chat", json={"objective": "demo"})
+        r = await ac.post("/chat", json={"objective": "demo", "project_id": 1})
         body = r.json()
         assert r.status_code == 200
         assert "html" in body and "summary" in body
@@ -26,7 +26,7 @@ async def test_chat_endpoint():
 async def test_ws_stream():
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         async with aconnect_ws("http://test/stream", ac) as ws:
-            await ws.send_json({"objective": "demo"})
+            await ws.send_json({"objective": "demo", "project_id": 1})
             chunk = await ws.receive_json()
             # Le stub renvoie un chunk 'plan'
             assert "plan" in chunk

--- a/tests/test_core_loop.py
+++ b/tests/test_core_loop.py
@@ -1,7 +1,7 @@
 import orchestrator.core_loop as cl
 
 def test_loop():
-    mem = cl.Memory()
+    mem = cl.Memory(project_id=1)
     state = cl.LoopState(objective="Dire bonjour en français", mem_obj=mem)
     out = cl.graph.invoke(state)
     assert "réussie" in out["result"].lower()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -4,7 +4,7 @@ from agents.schemas import ExecResult
 def test_todo_e2e():
     state = cl.LoopState(
         objective="Construis une todo-app React",
-        mem_obj=cl.Memory()
+        mem_obj=cl.Memory(project_id=1)
     )
     out = cl.graph.invoke(state)
 

--- a/tests/test_project_scope.py
+++ b/tests/test_project_scope.py
@@ -1,0 +1,20 @@
+import os
+import orchestrator.core_loop as cl
+import orchestrator.crud as crud
+
+
+def test_project_memory_is_isolated(tmp_path):
+    os.environ['ORCH_DB_URL'] = str(tmp_path / 'test.db')
+    crud.init_db()
+    p1 = crud.create_project(crud.ProjectCreate(name='A'))
+    p2 = crud.create_project(crud.ProjectCreate(name='B'))
+
+    mem_a = cl.Memory(project_id=p1.id)
+    mem_b = cl.Memory(project_id=p2.id)
+
+    mem_a.add('role', 'contentA')
+    mem_b.add('role', 'contentB')
+
+    items_a = mem_a.fetch()
+    assert all('contentA' in c for _, c in items_a)
+    assert not any('contentB' in c for _, c in items_a)


### PR DESCRIPTION
## Summary
- store project_id in Memory traces
- expose project CRUD and items endpoints
- propagate project_id from frontend
- show project selector in layout
- disable objective input without a project
- add tests for project isolation

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68808b6223c0833085ffa8898ea7e6e8