### PR TITLE
Implement project scoped items and selector

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,9 +1,14 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 from api.ws import router as ws_router
 from orchestrator.core_loop import graph, LoopState, Memory
 from orchestrator import crud
-from orchestrator.models import ProjectCreate, BacklogItemCreate
+from orchestrator.models import (
+    ProjectCreate,
+    BacklogItemCreate,
+    BacklogItemUpdate,
+    BacklogItem,
+)
 
 app = FastAPI()
 crud.init_db()
@@ -36,7 +41,8 @@ async def ping():
 @app.post("/chat")
 async def chat(payload: dict):
     objective = payload.get("objective", "")
-    state = LoopState(objective=objective, mem_obj=Memory())
+    project_id = payload.get("project_id")
+    state = LoopState(objective=objective, project_id=project_id, mem_obj=Memory())
     final = graph.invoke(state)
     return final["render"]  # html + summary
 
@@ -64,22 +70,78 @@ async def delete_project(project_id: int):
 
 
 # ---- Backlog item endpoints ----
+
+@app.get("/items", response_model=list[BacklogItem])
+async def list_items(
+    project_id: int = Query(...),
+    type: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+):
+    return crud.get_items(project_id=project_id, type=type, limit=limit, offset=offset)
+
+
+@app.post("/items", response_model=BacklogItem, status_code=201)
+async def create_item(item: BacklogItemCreate):
+    if item.parent_id is not None:
+        parent = crud.get_item(item.parent_id)
+        if not parent or parent.project_id != item.project_id:
+            raise HTTPException(status_code=400, detail="invalid parent_id")
+        if parent.type != "folder":
+            raise HTTPException(status_code=400, detail="parent must be folder")
+    return crud.create_item(item)
+
+
+@app.get("/items/{item_id}", response_model=BacklogItem)
+async def read_item(item_id: int, project_id: int | None = Query(None)):
+    item = crud.get_item(item_id)
+    if not item:
+        raise HTTPException(status_code=404)
+    if project_id is not None and item.project_id != project_id:
+        raise HTTPException(status_code=404)
+    return item
+
+
+@app.patch("/items/{item_id}", response_model=BacklogItem)
+async def update_item(item_id: int, payload: BacklogItemUpdate):
+    item = crud.get_item(item_id)
+    if not item:
+        raise HTTPException(status_code=404)
+    data = payload.model_dump(exclude_unset=True)
+    if "parent_id" in data and data["parent_id"] is not None:
+        new_parent = crud.get_item(data["parent_id"])
+        if not new_parent or new_parent.project_id != item.project_id:
+            raise HTTPException(status_code=400, detail="invalid parent_id")
+        if new_parent.type != "folder" or new_parent.id == item_id:
+            raise HTTPException(status_code=400, detail="invalid hierarchy")
+        current = new_parent
+        while current.parent_id is not None:
+            if current.parent_id == item_id:
+                raise HTTPException(status_code=400, detail="cycle detected")
+            current = crud.get_item(current.parent_id)
+            if current is None:
+                break
+    return crud.update_item(item_id, BacklogItemUpdate(**data))
+
+
+@app.delete("/items/{item_id}", status_code=204)
+async def delete_item(item_id: int):
+    item = crud.get_item(item_id)
+    if not item:
+        raise HTTPException(status_code=404)
+    if crud.item_has_children(item_id):
+        raise HTTPException(status_code=400, detail="item has children")
+    crud.delete_item(item_id)
+    return None
+
+
+# compatibility helpers for scoped routes
 @app.get("/projects/{project_id}/items")
-async def list_items(project_id: int):
+async def list_items_scoped(project_id: int):
     return crud.get_items(project_id)
 
 
 @app.post("/projects/{project_id}/items")
-async def create_item(project_id: int, item: BacklogItemCreate):
+async def create_item_scoped(project_id: int, item: BacklogItemCreate):
     item.project_id = project_id
     return crud.create_item(item)
-
-
-@app.put("/items/{item_id}")
-async def update_item(item_id: int, item: BacklogItemCreate):
-    return crud.update_item(item_id, item)
-
-
-@app.delete("/items/{item_id}")
-async def delete_item(item_id: int):
-    return crud.delete_item(item_id)

--- a/api/ws.py
+++ b/api/ws.py
@@ -9,12 +9,13 @@ router = APIRouter()
 async def stream_chat(ws: WebSocket):
     await ws.accept()
     try:
-        # 1) Attend le 1er message JSON : {"objective": "..."}
+        # 1) Attend le 1er message JSON : {"objective": "...", "project_id": 1}
         payload = await ws.receive_json()
         objective = payload.get("objective", "")
+        project_id = payload.get("project_id")
 
         # 2) Prépare l’état initial
-        state = LoopState(objective=objective, mem_obj=Memory())
+        state = LoopState(objective=objective, project_id=project_id, mem_obj=Memory())
 
         # 3) Stream LangGraph
         async for chunk in graph.astream(state):

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { ProjectProvider } from "@/context/ProjectContext";
+import ProjectSelector from "@/components/ProjectSelector";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,7 +29,12 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <ProjectProvider>{children}</ProjectProvider>
+        <ProjectProvider>
+          <div className="p-4 border-b">
+            <ProjectSelector />
+          </div>
+          {children}
+        </ProjectProvider>
       </body>
     </html>
   );

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -1,11 +1,11 @@
-export function connectWS(objective: string) {
+export function connectWS(objective: string, projectId?: number) {
   const wsUrl = (process.env.NEXT_PUBLIC_API_URL || "ws://localhost:8000").replace(
     /^http/,
     "ws"
   );
   const ws = new WebSocket(`${wsUrl}/stream`);
   ws.addEventListener("open", () => {
-    ws.send(JSON.stringify({ objective }));
+    ws.send(JSON.stringify({ objective, project_id: projectId }));
   });
   return ws;
 }

--- a/orchestrator/core_loop.py
+++ b/orchestrator/core_loop.py
@@ -44,6 +44,7 @@ class Memory:
 # ---------- State schema (Pydantic) ----------
 class LoopState(BaseModel):
     objective: str
+    project_id: int | None = None
     mem_obj: Memory
     memory: List[Any] = Field(default_factory=list)
     plan: Optional[Plan] = None

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -25,3 +25,10 @@ class BacklogItemCreate(BacklogItemBase):
 
 class BacklogItem(BacklogItemBase):
     id: int
+
+
+class BacklogItemUpdate(BaseModel):
+    title: str | None = None
+    description: str | None = None
+    type: str | None = None
+    parent_id: int | None = None


### PR DESCRIPTION
## Summary
- ensure `LoopState` stores `project_id`
- propagate `project_id` from the frontend to the WebSocket and chat API
- restore hierarchical item API and guard access by project
- add project selector to layout and disable objective input when no project

## Testing
- `poetry run ruff check api orchestrator --fix`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68809024060c8330933f55540a11d4dc