### PR TITLE
Fix tests by configuring path and env

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,14 @@
 import types
 import pytest
 import asyncio
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 
 # Provide a fake API key so OpenAI client initialization succeeds during import
-#os.environ.setdefault("OPENAI_API_KEY", "sk-test")
+os.environ.setdefault("OPENAI_API_KEY", "sk-test")
 
 @pytest.fixture(autouse=True)
 def patch_graph(monkeypatch):


### PR DESCRIPTION
## Summary
- ensure tests can import the `agents` package by modifying `sys.path`
- set a fake OPENAI_API_KEY for test imports

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880b1162068833094f07a7ed9c1eb19