### PR TITLE
feat: track run outputs and async orchestration

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -29,7 +29,18 @@ export default function Home() {
       body: JSON.stringify({ objective, project_id: currentProject?.id }),
     }).then(r => r.json());
 
-    setHistory(h => [...h, res.html]);
+    // poll run result
+    const poll = async () => {
+      const r = await fetch(`${apiUrl}/runs/${res.run_id}`);
+      const data = await r.json();
+      if (data.status === "success") {
+        setHistory(h => [...h, data.html]);
+        setIsLoading(false);
+      } else {
+        setTimeout(poll, 1000);
+      }
+    };
+    poll();
 
     // WebSocket streaming
     const ws = connectWS(objective, currentProject?.id);

--- a/frontend/src/app/runs/[runId]/page.tsx
+++ b/frontend/src/app/runs/[runId]/page.tsx
@@ -1,21 +1,52 @@
+"use client";
+import { useEffect, useState } from "react";
 import RunTimeline from "@/components/RunTimeline";
 
-async function getRun(id: string) {
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
-  const res = await fetch(`${apiUrl}/runs/${id}`, { cache: "no-store" });
-  if (!res.ok) throw new Error("run not found");
-  return res.json();
+interface Run {
+  run_id: string;
+  status: string;
+  html?: string | null;
+  summary?: string | null;
+  steps: { step: string; start: string; end: string }[];
 }
 
-export default async function RunDetail({ params }: { params: { runId: string } }) {
-  const run = await getRun(params.runId);
+export default function RunDetail({ params }: { params: { runId: string } }) {
+  const [run, setRun] = useState<Run | null>(null);
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchRun = async () => {
+      const res = await fetch(`${apiUrl}/runs/${params.runId}`);
+      if (!res.ok) return;
+      const data = await res.json();
+      if (!cancelled) {
+        setRun(data);
+        if (data.status !== "success") {
+          setTimeout(fetchRun, 1000);
+        }
+      }
+    };
+    fetchRun();
+    return () => {
+      cancelled = true;
+    };
+  }, [apiUrl, params.runId]);
+
+  if (!run) return <div className="p-6">Chargement...</div>;
+
   return (
     <div className="p-6 space-y-4">
       <h1 className="text-xl font-semibold">Run {params.runId}</h1>
       <RunTimeline run={run} />
-      <pre className="bg-gray-100 p-4 rounded text-sm overflow-auto">
-        {JSON.stringify(run, null, 2)}
-      </pre>
+      {run.status === "success" && (
+        <>
+          {run.html && (
+            <div className="prose" dangerouslySetInnerHTML={{ __html: run.html }} />
+          )}
+          {run.summary && <p>{run.summary}</p>}
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/RunTimeline.tsx
+++ b/frontend/src/components/RunTimeline.tsx
@@ -2,13 +2,13 @@
 import Link from "next/link";
 
 interface Step {
-  name: string;
-  started_at: string;
-  ended_at: string;
+  step: string;
+  start: string;
+  end: string;
 }
 
 interface Run {
-  id: string;
+  run_id: string;
   status: string;
   steps: Step[];
 }
@@ -20,21 +20,21 @@ const colors: Record<string, string> = {
 };
 
 export default function RunTimeline({ run }: { run: Run }) {
-  const durations = run.steps.map(s => new Date(s.ended_at).getTime() - new Date(s.started_at).getTime());
+  const durations = run.steps.map(s => new Date(s.end).getTime() - new Date(s.start).getTime());
   const total = durations.reduce((a, b) => a + b, 0) || 1;
   return (
     <div className="space-y-1">
       <div className="flex h-2 w-full overflow-hidden rounded">
         {run.steps.map((s, i) => (
           <div
-            key={s.name}
-            className={`${colors[s.name] || "bg-gray-400"} h-full`}
+            key={s.step}
+            className={`${colors[s.step] || "bg-gray-400"} h-full`}
             style={{ width: `${(durations[i] / total) * 100}%` }}
-            title={s.name}
+            title={s.step}
           />
         ))}
       </div>
-      <Link href={`/runs/${run.id}`} className="text-xs text-blue-500 hover:underline">
+      <Link href={`/runs/${run.run_id}`} className="text-xs text-blue-500 hover:underline">
         Détails du run
       </Link>
     </div>

--- a/frontend/src/components/RunsPanel.tsx
+++ b/frontend/src/components/RunsPanel.tsx
@@ -4,9 +4,9 @@ import RunTimeline from "./RunTimeline";
 import { useProjects } from "@/context/ProjectContext";
 
 interface Run {
-  id: string;
+  run_id: string;
   status: string;
-  steps: { name: string; started_at: string; ended_at: string }[];
+  steps: { step: string; start: string; end: string }[];
 }
 
 export default function RunsPanel() {
@@ -34,7 +34,7 @@ export default function RunsPanel() {
     <section className="space-y-4">
       <h2 className="text-xl font-semibold text-gray-800">Historique des runs</h2>
       {runs.map(run => (
-        <RunTimeline key={run.id} run={run} />
+        <RunTimeline key={run.run_id} run={run} />
       ))}
     </section>
   );

--- a/frontend/src/components/__tests__/RunsPanel.test.tsx
+++ b/frontend/src/components/__tests__/RunsPanel.test.tsx
@@ -25,7 +25,7 @@ afterEach(() => {
 
 it('renders runs when API returns an array', async () => {
   global.fetch = vi.fn().mockResolvedValue({
-    json: async () => [{ id: '1', status: 'ok', steps: [] }],
+    json: async () => [{ run_id: '1', status: 'ok', steps: [] }],
   });
 
   render(<RunsPanel />);
@@ -34,7 +34,7 @@ it('renders runs when API returns an array', async () => {
 
 it('supports object with runs property', async () => {
   global.fetch = vi.fn().mockResolvedValue({
-    json: async () => ({ runs: [{ id: '2', status: 'ok', steps: [] }] }),
+    json: async () => ({ runs: [{ run_id: '2', status: 'ok', steps: [] }] }),
   });
 
   render(<RunsPanel />);

--- a/orchestrator/core_loop.py
+++ b/orchestrator/core_loop.py
@@ -128,6 +128,8 @@ def writer(state: LoopState) -> dict:
     render = {"html": html, "summary": summary, "artifacts": []}
     state.mem_obj.add("agent-writer", summary)
     state.mem_obj.add("assistant", summary)
+    # mark run as finished with the final render
+    crud.finish_run(state.run_id, "success", render)
     return {"render": render, "result": summary}
 
 # ---------- Build & compile graph ----------

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -34,6 +34,9 @@ class Run(BaseModel):
     finished_at: datetime | None = None
     error: str | None = None
     steps: list[RunStep] = Field(default_factory=list)
+    html: str | None = None
+    summary: str | None = None
+    artifacts: list[str] | None = None
 
 
 # Base item model

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -1,5 +1,6 @@
 import pytest
 import types
+import asyncio
 from httpx import AsyncClient
 import api.main as main
 from httpx_ws.transport import ASGIWebSocketTransport
@@ -13,8 +14,14 @@ async def test_run_failure(monkeypatch):
         raise RuntimeError("boom")
     monkeypatch.setattr(main, "graph", types.SimpleNamespace(invoke=failing_invoke))
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        with pytest.raises(RuntimeError):
-            await ac.post("/chat", json={"objective": "fail"})
+        r = await ac.post("/chat", json={"objective": "fail"})
+        run_id = r.json()["run_id"]
+        for _ in range(200):
+            r2 = await ac.get(f"/runs/{run_id}")
+            data = r2.json()
+            if data["status"] != "running":
+                break
+            await asyncio.sleep(0.1)
     runs = crud.get_runs()
     assert runs and runs[-1].status == "failed"
     assert runs[-1].error


### PR DESCRIPTION
## Summary
- persist run HTML, summary and artifacts in SQLite and ORM
- execute orchestration in background thread and expose `/runs/{id}` for status and render
- poll runs on the frontend and show final render

## Testing
- `pytest`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68a5de16ed94833089fea446bc67ff87