### PR TITLE
Restore live run streaming with run_id support

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -5,7 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from api.ws import router as ws_router
 from uuid import uuid4
 from orchestrator.core_loop import graph, LoopState, Memory
-from orchestrator import crud
+from orchestrator import crud, stream
 from orchestrator.models import (
     ProjectCreate,
     BacklogItemCreate,
@@ -68,17 +68,26 @@ async def chat(payload: dict):
     crud.create_run(run_id, project_id)
     state = LoopState(objective=objective, project_id=project_id, run_id=run_id, mem_obj=Memory())
 
+    # Register a stream queue for this run so WebSocket clients can subscribe
+    loop = asyncio.get_event_loop()
+    stream.register(run_id, loop)
+
     def _run():
-        try:
-            final = graph.invoke(state)
-            render = final.get("render") if isinstance(final, dict) else None
-            if render is None and hasattr(state, "render"):
-                render = state.render
-            if render is None:
-                render = {"html": "<p>done</p>", "summary": "done", "artifacts": []}
-            crud.finish_run(run_id, "success", render)
-        except Exception as e:
-            crud.finish_run(run_id, "failed", error=str(e))
+        async def runner():
+            try:
+                async for chunk in graph.astream(state):
+                    node, data = next(iter(chunk.items()))
+                    stream.publish(run_id, {"node": node, "state": data})
+                render = getattr(state, "render", None)
+                if render is None:
+                    render = {"html": "<p>done</p>", "summary": "done", "artifacts": []}
+                crud.finish_run(run_id, "success", render)
+            except Exception as e:
+                crud.finish_run(run_id, "failed", error=str(e))
+            finally:
+                stream.close(run_id)
+
+        asyncio.run(runner())
 
     threading.Thread(target=_run, daemon=True).start()
     return {"run_id": run_id}

--- a/api/ws.py
+++ b/api/ws.py
@@ -1,35 +1,31 @@
 # api/ws.py
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
-from fastapi.encoders import jsonable_encoder
-from orchestrator.core_loop import graph, LoopState, Memory
-from orchestrator import crud
-from uuid import uuid4
+from orchestrator import stream
 
 router = APIRouter()
 
 @router.websocket("/stream")
 async def stream_chat(ws: WebSocket):
     await ws.accept()
-    run_id = None
     try:
         payload = await ws.receive_json()
-        objective = payload.get("objective", "")
-        project_id = payload.get("project_id")
-        run_id = str(uuid4())
-        crud.create_run(run_id, project_id)
-
-        state = LoopState(objective=objective, project_id=project_id, run_id=run_id, mem_obj=Memory())
-
-        await ws.send_json({"run_id": run_id})
-        async for chunk in graph.astream(state):
-            await ws.send_json(jsonable_encoder(chunk))
-
-        crud.finish_run(run_id, "success")
+        run_id = payload.get("run_id")
+        if not run_id:
+            await ws.close(code=1008, reason="run_id required")
+            return
+        queue = stream.get(run_id)
+        if queue is None:
+            await ws.close(code=404, reason="unknown run")
+            return
+        while True:
+            chunk = await queue.get()
+            if chunk is None:
+                break
+            await ws.send_json(chunk)
+        stream.discard(run_id)
         await ws.close(code=1000)
     except WebSocketDisconnect:
-        print("Client disconnected")
+        pass
     except Exception as e:
-        if run_id:
-            crud.finish_run(run_id, "failed", str(e))
         msg = (str(e) or "internal error")[:120]
         await ws.close(code=1011, reason=msg)

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -28,10 +28,11 @@ export default function Home() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ objective: runObjective, project_id: currentProject?.id }),
     }).then(r => r.json());
+    const runId = res.run_id;
 
     // poll run result
     const poll = async () => {
-      const r = await fetch(`${apiUrl}/runs/${res.run_id}`);
+      const r = await fetch(`${apiUrl}/runs/${runId}`);
       const data = await r.json();
       if (data.status === "success") {
         setHistory(h => [
@@ -53,7 +54,7 @@ export default function Home() {
     poll();
 
     // WebSocket streaming
-    const ws = connectWS(runObjective, currentProject?.id);
+    const ws = connectWS(runId);
     ws.onmessage = evt => {
       const chunk = JSON.parse(evt.data);
       viewerRef.current?.push(chunk);

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -1,11 +1,11 @@
-export function connectWS(objective: string, projectId?: number) {
+export function connectWS(runId: string) {
   const wsUrl = (process.env.NEXT_PUBLIC_API_URL || "ws://localhost:8000").replace(
     /^http/,
     "ws"
   );
   const ws = new WebSocket(`${wsUrl}/stream`);
   ws.addEventListener("open", () => {
-    ws.send(JSON.stringify({ objective, project_id: projectId }));
+    ws.send(JSON.stringify({ run_id: runId }));
   });
   return ws;
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,5 +63,3 @@ def patch_graph(monkeypatch):
     import api.main as main
     monkeypatch.setattr(main, "graph", FakeGraph)
 
-    import api.ws as ws
-    monkeypatch.setattr(ws, "graph", FakeGraph)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -50,12 +50,12 @@ async def test_chat_endpoint(monkeypatch):
 @pytest.mark.asyncio
 async def test_ws_stream():
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        r = await ac.post("/chat", json={"objective": "demo"})
+        run_id = r.json()["run_id"]
         async with aconnect_ws("http://test/stream", ac) as ws:
-            await ws.send_json({"objective": "demo"})
-            run_info = await ws.receive_json()
-            assert "run_id" in run_info
+            await ws.send_json({"run_id": run_id})
             chunk = await ws.receive_json()
-            assert "plan" in chunk or "execute" in chunk or "write" in chunk
+            assert chunk["node"] in {"plan", "execute", "write"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- stream LangGraph steps to clients via per-run queues
- expose run progress over WebSocket using `run_id`
- update frontend WebSocket client and StreamViewer to display step updates

## Testing
- `pytest -q`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5fbb4f5688330a5824dbf2d07703c