### PR TITLE
feat(core): add /health endpoint, env-based API base URL, and UI StatusBar for API/WS connectivity

### DIFF
--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -1,0 +1,2 @@
+# Base URL for backend API; override in production to point to your server or proxy
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -34,3 +34,13 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Configuration
+
+Set the backend API base URL in `.env.local`:
+
+```bash
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+```
+
+If unset, the app falls back to `/api`, allowing the frontend to proxy requests to the backend.

--- a/frontend/src/app/runs/[runId]/page.tsx
+++ b/frontend/src/app/runs/[runId]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import RunTimeline from "@/components/RunTimeline";
+import { http } from "@/lib/api";
 
 interface Run {
   run_id: string;
@@ -12,12 +13,10 @@ interface Run {
 
 export default function RunDetail({ params }: { params: { runId: string } }) {
   const [run, setRun] = useState<Run | null>(null);
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
-
   useEffect(() => {
     let cancelled = false;
     const fetchRun = async () => {
-      const res = await fetch(`${apiUrl}/runs/${params.runId}`);
+      const res = await http(`/runs/${params.runId}`);
       if (!res.ok) return;
       const data = await res.json();
       if (!cancelled) {
@@ -31,7 +30,7 @@ export default function RunDetail({ params }: { params: { runId: string } }) {
     return () => {
       cancelled = true;
     };
-  }, [apiUrl, params.runId]);
+  }, [params.runId]);
 
   if (!run) return <div className="p-6">Chargement...</div>;
 

--- a/frontend/src/components/BacklogPane.tsx
+++ b/frontend/src/components/BacklogPane.tsx
@@ -9,6 +9,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ItemDialog } from './ItemDialog';
 import { BacklogItem } from '@/models/backlogItem';
 import { mutate } from 'swr';
+import { http } from '@/lib/api';
 
 export default function BacklogPane() {
   const { currentProject } = useProjects();
@@ -28,11 +29,11 @@ export default function BacklogPane() {
   const handleSave = async (item: Partial<BacklogItem>) => {
     try {
       const method = item.id ? 'PATCH' : 'POST';
-      const url = item.id ? `/api/items/${item.id}` : '/api/items';
+      const url = item.id ? `/items/${item.id}` : '/items';
 
       console.log('Saving item:', item); // Debug log
 
-      const response = await fetch(url, {
+      const response = await http(url, {
         method,
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(item),
@@ -48,7 +49,7 @@ export default function BacklogPane() {
       const result = await response.json();
       console.log('Save successful:', result); // Debug log
       
-      mutate(`/api/items?project_id=${currentProject?.id}`);
+      mutate(`/items?project_id=${currentProject?.id}`);
     } catch (error) {
       console.error('Save error:', error);
       alert(`Erreur: ${error.message}`);

--- a/frontend/src/components/ItemDialog.tsx
+++ b/frontend/src/components/ItemDialog.tsx
@@ -21,6 +21,7 @@ import { BacklogItem } from '@/models/backlogItem';
 import { useItems } from '@/lib/hooks';
 import { useBacklog } from '@/context/BacklogContext';
 import { mutate } from 'swr';
+import { http } from '@/lib/api';
 import dynamic from 'next/dynamic';
 const Loader2 = dynamic(
   () => import('lucide-react').then((mod) => ({ default: mod.Loader2 })),
@@ -391,7 +392,7 @@ export function ItemDialog({ isOpen, onClose, item, projectId, onSave }: ItemDia
               disabled={isGeneratingFeatures}
               onClick={async () => {
                 setIsGeneratingFeatures(true);
-                const resp = await fetch('/api/feature_proposals', {
+                const resp = await http('/feature_proposals', {
                   method: 'POST',
                   headers: { 'Content-Type': 'application/json' },
                   body: JSON.stringify({
@@ -401,7 +402,7 @@ export function ItemDialog({ isOpen, onClose, item, projectId, onSave }: ItemDia
                   }),
                 });
                 if (resp.ok) {
-                  await mutate(`/api/items?project_id=${projectId}`);
+                  await mutate(`/items?project_id=${projectId}`);
                   onClose();
                 }
                 setIsGeneratingFeatures(false);
@@ -447,7 +448,7 @@ export function ItemDialog({ isOpen, onClose, item, projectId, onSave }: ItemDia
                 if (item) {
                   await deleteItem(item.id);
                   // rafraîchir la liste des items
-                  mutate(`/api/items?project_id=${projectId}`);
+                  mutate(`/items?project_id=${projectId}`);
                   setShowDeleteConfirm(false);
                   onClose();
                 }

--- a/frontend/src/components/RunsPanel.tsx
+++ b/frontend/src/components/RunsPanel.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import RunTimeline from "./RunTimeline";
 import { useProjects } from "@/context/ProjectContext";
+import { http } from "@/lib/api";
 
 interface Run {
   run_id: string;
@@ -14,9 +15,8 @@ export default function RunsPanel() {
   const [runs, setRuns] = useState<Run[]>([]);
 
   useEffect(() => {
-    const apiUrl = process.env.NEXT_PUBLIC_API_URL;
     if (!currentProject) return;
-    fetch(`${apiUrl}/runs?project_id=${currentProject.id}`)
+    http(`/runs?project_id=${currentProject.id}`)
       .then(r => r.json())
       .then(data => {
         if (Array.isArray(data)) {

--- a/frontend/src/components/StatusBar.tsx
+++ b/frontend/src/components/StatusBar.tsx
@@ -1,0 +1,45 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { http } from "@/lib/api";
+import { connectWS } from "@/lib/ws";
+
+export default function StatusBar() {
+  const [apiOk, setApiOk] = useState<boolean | null>(null);
+  const [wsOk, setWsOk] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const check = () => {
+      http("/health")
+        .then(r => r.json())
+        .then(d => setApiOk(d.status === "ok"))
+        .catch(() => setApiOk(false));
+      try {
+        const ws = connectWS("/stream");
+        ws.onopen = () => {
+          setWsOk(true);
+          ws.close();
+        };
+        ws.onerror = () => setWsOk(false);
+      } catch {
+        setWsOk(false);
+      }
+    };
+    check();
+    const id = setInterval(check, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  const render = (label: string, state: boolean | null, okText: string, downText: string) => {
+    const variant = state === null ? "secondary" : state ? "default" : "destructive";
+    const text = state === null ? `${label}: …` : state ? `${label}: ${okText}` : `${label}: ${downText}`;
+    return <Badge variant={variant}>{text}</Badge>;
+  };
+
+  return (
+    <div className="fixed top-0 left-0 right-0 flex gap-2 p-2 text-xs z-50">
+      {render("API", apiOk, "OK", "Down")}
+      {render("WS", wsOk, "Connected", "Disconnected")}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/RunsPanel.test.tsx
+++ b/frontend/src/components/__tests__/RunsPanel.test.tsx
@@ -16,7 +16,7 @@ declare global {
 }
 
 beforeAll(() => {
-  process.env.NEXT_PUBLIC_API_URL = 'http://api.test';
+  process.env.NEXT_PUBLIC_API_BASE_URL = 'http://api.test';
 });
 
 afterEach(() => {

--- a/frontend/src/context/BacklogContext.tsx
+++ b/frontend/src/context/BacklogContext.tsx
@@ -2,6 +2,7 @@
 import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 import { BacklogItem } from '@/models/backlogItem';
 import { useProjects } from '@/context/ProjectContext';
+import { http } from '@/lib/api';
 
 interface BacklogContextType {
   items: BacklogItem[];
@@ -18,8 +19,6 @@ export const BacklogProvider = ({ children }: { children: ReactNode }) => {
   const { currentProject } = useProjects();
   const [items, setItems] = useState<BacklogItem[]>([]);
   const [isLoading, setIsLoading] = useState(false);
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL || '';
-
   const fetchItems = async () => {
     if (!currentProject) {
       setItems([]);
@@ -27,7 +26,7 @@ export const BacklogProvider = ({ children }: { children: ReactNode }) => {
     }
     setIsLoading(true);
     try {
-      const res = await fetch(`${apiUrl}/api/items?project_id=${currentProject.id}`);
+      const res = await http(`/items?project_id=${currentProject.id}`);
       const data = await res.json();
       setItems(data);
     } catch (err) {
@@ -40,7 +39,7 @@ export const BacklogProvider = ({ children }: { children: ReactNode }) => {
   const createItem = async (item: Omit<BacklogItem, 'id'>) => {
     if (!currentProject) return null;
     try {
-      const res = await fetch(`${apiUrl}/api/items`, {
+      const res = await http(`/items`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(item),
@@ -57,7 +56,7 @@ export const BacklogProvider = ({ children }: { children: ReactNode }) => {
 
   const updateItem = async (id: number, item: Omit<BacklogItem, 'id'>) => {
     try {
-      const res = await fetch(`${apiUrl}/api/items/${id}`, {
+      const res = await http(`/items/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(item),
@@ -74,7 +73,7 @@ export const BacklogProvider = ({ children }: { children: ReactNode }) => {
 
   const deleteItem = async (id: number) => {
     try {
-      const res = await fetch(`${apiUrl}/api/items/${id}`, { method: 'DELETE' });
+      const res = await http(`/items/${id}`, { method: 'DELETE' });
       if (!res.ok) throw new Error('Failed');
       await fetchItems();
       return true;

--- a/frontend/src/context/ProjectContext.tsx
+++ b/frontend/src/context/ProjectContext.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { Project } from '@/models/project'; // Nous créerons ce modèle
+import { http } from '@/lib/api';
 
 interface ProjectContextType {
   projects: Project[];
@@ -19,12 +20,10 @@ export const ProjectProvider = ({ children }: { children: ReactNode }) => {
   const [projects, setProjects] = useState<Project[]>([]);
   const [currentProject, setCurrentProject] = useState<Project | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL || '';
-
   const fetchProjects = async () => {
     setIsLoading(true);
     try {
-      const response = await fetch(`${apiUrl}/projects`);
+      const response = await http(`/projects`);
       const data = await response.json();
       setProjects(data);
       if (data.length > 0 && !currentProject) {
@@ -41,7 +40,7 @@ export const ProjectProvider = ({ children }: { children: ReactNode }) => {
 
   const createProject = async (name: string, description?: string) => {
     try {
-      const response = await fetch(`${apiUrl}/projects`, {
+      const response = await http(`/projects`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name, description }),
@@ -59,7 +58,7 @@ export const ProjectProvider = ({ children }: { children: ReactNode }) => {
 
   const updateProject = async (id: number, name: string, description?: string) => {
     try {
-      const response = await fetch(`${apiUrl}/projects/${id}`, {
+      const response = await http(`/projects/${id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name, description }),
@@ -79,7 +78,7 @@ export const ProjectProvider = ({ children }: { children: ReactNode }) => {
 
   const deleteProject = async (id: number) => {
     try {
-      const response = await fetch(`${apiUrl}/projects/${id}`, {
+      const response = await http(`/projects/${id}`, {
         method: 'DELETE',
       });
       if (!response.ok) throw new Error('Failed to delete project');

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getApiBaseUrl } from './api';
+
+describe('getApiBaseUrl', () => {
+  beforeEach(() => {
+    delete process.env.NEXT_PUBLIC_API_BASE_URL;
+  });
+
+  it('returns env value without trailing slash', () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://example.com/';
+    expect(getApiBaseUrl()).toBe('http://example.com');
+  });
+
+  it('falls back to /api when env missing', () => {
+    expect(getApiBaseUrl()).toBe('/api');
+  });
+
+  it('handles relative base', () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = '/backend/';
+    expect(getApiBaseUrl()).toBe('/backend');
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,12 @@
+export function getApiBaseUrl(): string {
+  let base = process.env.NEXT_PUBLIC_API_BASE_URL ?? '/api';
+  if (!base) return '';
+  base = base.replace(/\/+$/, '');
+  return base;
+}
+
+export function http(path: string, init?: RequestInit) {
+  const base = getApiBaseUrl();
+  const url = `${base}${path.startsWith('/') ? path : '/' + path}`;
+  return fetch(url, init);
+}

--- a/frontend/src/lib/hooks.ts
+++ b/frontend/src/lib/hooks.ts
@@ -1,7 +1,8 @@
 import useSWR from 'swr';
 import { BacklogItem } from '@/models/backlogItem';
+import { http } from '@/lib/api';
 
-const fetcher = (url: string) => fetch(url).then(res => res.json());
+const fetcher = (url: string) => http(url).then(res => res.json());
 
 export interface TreeNode extends BacklogItem {
   children: TreeNode[];
@@ -9,7 +10,7 @@ export interface TreeNode extends BacklogItem {
 
 export function useItems(projectId: number | null) {
   const { data, error, isLoading } = useSWR<BacklogItem[]>(
-    projectId ? `/api/items?project_id=${projectId}` : null,
+    projectId ? `/items?project_id=${projectId}` : null,
     fetcher
   );
 

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -1,11 +1,18 @@
-export function connectWS(runId: string) {
-  const wsUrl = (process.env.NEXT_PUBLIC_API_URL || "ws://localhost:8000").replace(
-    /^http/,
-    "ws"
-  );
-  const ws = new WebSocket(`${wsUrl}/stream`);
-  ws.addEventListener("open", () => {
-    ws.send(JSON.stringify({ run_id: runId }));
-  });
-  return ws;
+import { getApiBaseUrl } from './api';
+
+function getWsBaseUrl(): string {
+  const api = getApiBaseUrl();
+  if (api.startsWith('http')) {
+    return api.replace(/^http/, 'ws');
+  }
+  const { protocol, host } = window.location;
+  const wsProto = protocol === 'https:' ? 'wss:' : 'ws:';
+  const base = api ? api : '';
+  return `${wsProto}//${host}${base}`;
+}
+
+export function connectWS(path: string): WebSocket {
+  const base = getWsBaseUrl().replace(/\/+$, '');
+  const url = `${base}${path.startsWith('/') ? path : '/' + path}`;
+  return new WebSocket(url);
 }

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,23 @@
+import pytest
+from httpx import AsyncClient
+from httpx_ws.transport import ASGIWebSocketTransport
+from api.main import app
+from datetime import datetime
+
+transport = ASGIWebSocketTransport(app=app)
+
+@pytest.mark.asyncio
+async def test_health_endpoint_status():
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        res = await ac.get("/health")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["status"] == "ok"
+    assert data["service"] == "orchestrator"
+    assert "version" in data and data["version"]
+
+@pytest.mark.asyncio
+async def test_health_time_is_isoformat():
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        res = await ac.get("/health")
+    datetime.fromisoformat(res.json()["time"])  # should not raise


### PR DESCRIPTION
## Summary
- add FastAPI `/health` endpoint with version info and CORS for common dev ports
- centralize frontend API base URL via `NEXT_PUBLIC_API_BASE_URL` with StatusBar for API/WebSocket
- document configuration and add tests for health endpoint and API URL helper

## Testing
- `poetry run pytest tests/test_health.py`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a611b61fdc833090ace272d76b3292