### PR TITLE
fix: trim trailing slashes in WebSocket base URL

### DIFF
--- a/frontend/src/lib/ws.test.ts
+++ b/frontend/src/lib/ws.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { connectWS } from './ws';
+
+class MockWebSocket {
+  url: string;
+  constructor(url: string) {
+    this.url = url;
+  }
+}
+
+global.WebSocket = MockWebSocket as any;
+
+describe('connectWS', () => {
+  const base = `ws://${window.location.host}/api`;
+
+  it('adds a leading slash when missing', () => {
+    const ws = connectWS('chat');
+    expect(ws.url).toBe(`${base}/chat`);
+  });
+
+  it('uses existing leading slash', () => {
+    const ws = connectWS('/chat');
+    expect(ws.url).toBe(`${base}/chat`);
+  });
+});

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -12,7 +12,7 @@ function getWsBaseUrl(): string {
 }
 
 export function connectWS(path: string): WebSocket {
-  const base = getWsBaseUrl().replace(/\/+$, '');
+  const base = getWsBaseUrl().replace(/\/+$/, '');
   const url = `${base}${path.startsWith('/') ? path : '/' + path}`;
   return new WebSocket(url);
 }


### PR DESCRIPTION
## Summary
- ensure `connectWS` strips trailing slashes from base WebSocket URL
- add unit tests for `connectWS`

## Testing
- `pnpm exec tsc src/lib/ws.ts`
- `pnpm test --run`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6275b05bc8330ae2c4adcadc61203