### PR TITLE
feat: expose run query endpoints

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -13,7 +13,8 @@ from orchestrator.models import (
     BacklogItemCreate,
     BacklogItemUpdate,
     BacklogItem,
-    Run,
+    RunDetail,
+    RunSummary,
     FeatureCreate,
 )
 import agents.writer as writer
@@ -113,7 +114,7 @@ async def chat(payload: dict):
     return {"run_id": run_id}
 
 
-@app.get("/runs/{run_id}", response_model=Run)
+@app.get("/runs/{run_id}", response_model=RunDetail)
 async def read_run(run_id: str):
     run = crud.get_run(run_id)
     if not run:
@@ -121,7 +122,7 @@ async def read_run(run_id: str):
     return run
 
 
-@app.get("/runs", response_model=list[Run])
+@app.get("/runs", response_model=list[RunSummary])
 async def list_runs(project_id: int | None = Query(None)):
     return crud.get_runs(project_id)
 

--- a/orchestrator/crud.py
+++ b/orchestrator/crud.py
@@ -198,7 +198,7 @@ def get_run(run_id: str) -> dict | None:
         return None
     run = dict(row)
     cur.execute(
-        "SELECT node, timestamp, content FROM run_steps WHERE run_id = ? ORDER BY step_order",
+        "SELECT step_order as 'order', node, timestamp, content FROM run_steps WHERE run_id = ? ORDER BY step_order",
         (run_id,),
     )
     run["steps"] = [dict(r) for r in cur.fetchall()]

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -16,13 +16,14 @@ class ProjectCreate(BaseModel):
 class RunStep(BaseModel):
     """Timeline entry for a run."""
 
+    order: int
     node: str
     timestamp: datetime
     content: str
 
 
-class Run(BaseModel):
-    """High level metadata for an orchestrator run."""
+class RunDetail(BaseModel):
+    """Detailed representation of an orchestrator run."""
 
     run_id: str
     project_id: int | None = None
@@ -33,6 +34,21 @@ class Run(BaseModel):
     html: str | None = None
     summary: str | None = None
     steps: list[RunStep] = Field(default_factory=list)
+
+
+class RunSummary(BaseModel):
+    """Lightweight run metadata for listings."""
+
+    run_id: str
+    project_id: int | None = None
+    objective: str
+    status: Literal["running", "done"]
+    created_at: datetime
+    completed_at: datetime | None = None
+
+
+# Backward compatibility for existing imports
+Run = RunDetail
 
 
 # Base item model

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -1,12 +1,22 @@
 import uuid
 
-import uuid
+import pytest
+from httpx import AsyncClient, ASGITransport
+from api.main import app
 from orchestrator import crud
 
 
 def setup_module(module):
     """Ensure a clean database for these tests."""
     crud.init_db()
+    conn = crud.get_db_connection()
+    conn.execute("DELETE FROM run_steps")
+    conn.execute("DELETE FROM runs")
+    conn.commit()
+    conn.close()
+
+
+def _reset_runs():
     conn = crud.get_db_connection()
     conn.execute("DELETE FROM run_steps")
     conn.execute("DELETE FROM runs")
@@ -45,12 +55,7 @@ def test_finish_run_updates_status_and_render():
 
 
 def test_get_runs_filters_by_project():
-    conn = crud.get_db_connection()
-    conn.execute("DELETE FROM run_steps")
-    conn.execute("DELETE FROM runs")
-    conn.commit()
-    conn.close()
-
+    _reset_runs()
     r1 = str(uuid.uuid4())
     r2 = str(uuid.uuid4())
     crud.create_run(r1, "obj1", 1)
@@ -59,4 +64,54 @@ def test_get_runs_filters_by_project():
     runs_project1 = crud.get_runs(1)
     assert len(runs_project1) == 1
     assert runs_project1[0]["run_id"] == r1
+
+
+@pytest.mark.asyncio
+async def test_get_run_endpoint_and_steps_order():
+    _reset_runs()
+    run_id = str(uuid.uuid4())
+    crud.create_run(run_id, "api test", 1)
+    crud.record_run_step(run_id, "first", "one")
+    crud.record_run_step(run_id, "second", "two")
+    crud.finish_run(run_id, "<p>done</p>", "summary")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get(f"/runs/{run_id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["run_id"] == run_id
+    assert [s["order"] for s in data["steps"]] == [1, 2]
+    assert [s["node"] for s in data["steps"]] == ["first", "second"]
+
+
+@pytest.mark.asyncio
+async def test_get_run_endpoint_not_found():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/runs/nonexistent")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_runs_endpoint_filters_by_project():
+    _reset_runs()
+    r1 = str(uuid.uuid4())
+    r2 = str(uuid.uuid4())
+    crud.create_run(r1, "obj1", 1)
+    crud.create_run(r2, "obj2", 2)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        res_all = await ac.get("/runs")
+        assert res_all.status_code == 200
+        ids = {r["run_id"] for r in res_all.json()}
+        assert ids == {r1, r2}
+
+        res_proj1 = await ac.get("/runs", params={"project_id": 1})
+        assert res_proj1.status_code == 200
+        data_proj1 = res_proj1.json()
+        assert len(data_proj1) == 1 and data_proj1[0]["run_id"] == r1
+
+        res_none = await ac.get("/runs", params={"project_id": 999})
+        assert res_none.status_code == 200
+        assert res_none.json() == []
 


### PR DESCRIPTION
## Summary
- add RunDetail/RunSummary models with step ordering
- expose GET /runs/{run_id} and GET /runs with project filter
- test run retrieval and listing through API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6316f89e88330aa74996e2ce80fb7