### PR TITLE
feat(frontend): add backlog view tabs and tree interactions

### DIFF
--- a/frontend/src/components/BacklogPane.tsx
+++ b/frontend/src/components/BacklogPane.tsx
@@ -1,15 +1,12 @@
 "use client";
 import { useState } from 'react';
 import { useProjects } from '@/context/ProjectContext';
-import { ItemTree } from '@/components/ItemTree';
-import { BacklogTable } from '@/components/BacklogTable';
-import { BacklogDiagram } from '@/components/BacklogDiagram';
 import { Button } from '@/components/ui/button';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ItemDialog } from './ItemDialog';
 import { BacklogItem } from '@/models/backlogItem';
 import { mutate } from 'swr';
 import { http } from '@/lib/api';
+import { BacklogViewTabs } from '@/components/BacklogViewTabs';
 
 export default function BacklogPane() {
   const { currentProject } = useProjects();
@@ -65,25 +62,10 @@ export default function BacklogPane() {
         </Button>
       </div>
       
-      <Tabs defaultValue="tree" className="w-full">
-        <TabsList className="grid w-full grid-cols-3 mb-4">
-          <TabsTrigger value="diagram">Vue Diagramme</TabsTrigger>
-          <TabsTrigger value="tree">Vue Arbre</TabsTrigger>
-          <TabsTrigger value="table">Vue Table</TabsTrigger>
-        </TabsList>
-        
-        <TabsContent value="tree">
-          <ItemTree projectId={currentProject?.id ?? null} onEdit={handleEditItem} />
-        </TabsContent>
-        
-        <TabsContent value="table">
-          <BacklogTable projectId={currentProject?.id ?? null} onEdit={handleEditItem} />
-        </TabsContent>
-        
-        <TabsContent value="diagram">
-          <BacklogDiagram projectId={currentProject?.id ?? null} onEdit={handleEditItem} />
-        </TabsContent>
-      </Tabs>
+      <BacklogViewTabs
+        projectId={currentProject?.id ?? null}
+        onEdit={handleEditItem}
+      />
       
       {currentProject && (
         <ItemDialog

--- a/frontend/src/components/BacklogViewTabs.tsx
+++ b/frontend/src/components/BacklogViewTabs.tsx
@@ -1,0 +1,35 @@
+"use client";
+import { ItemTree } from '@/components/ItemTree';
+import { BacklogTable } from '@/components/BacklogTable';
+import { BacklogDiagram } from '@/components/BacklogDiagram';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { BacklogItem } from '@/models/backlogItem';
+
+interface BacklogViewTabsProps {
+  projectId: number | null;
+  onEdit: (item: BacklogItem) => void;
+}
+
+export function BacklogViewTabs({ projectId, onEdit }: BacklogViewTabsProps) {
+  return (
+    <Tabs defaultValue="tree" className="w-full">
+      <TabsList className="grid w-full grid-cols-3 mb-4">
+        <TabsTrigger value="diagram">Vue Diagramme</TabsTrigger>
+        <TabsTrigger value="tree">Vue Arbre</TabsTrigger>
+        <TabsTrigger value="table">Vue Table</TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="tree">
+        <ItemTree projectId={projectId} onEdit={onEdit} />
+      </TabsContent>
+
+      <TabsContent value="table">
+        <BacklogTable projectId={projectId} onEdit={onEdit} />
+      </TabsContent>
+
+      <TabsContent value="diagram">
+        <BacklogDiagram projectId={projectId} onEdit={onEdit} />
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/frontend/src/components/ItemTree.tsx
+++ b/frontend/src/components/ItemTree.tsx
@@ -4,12 +4,15 @@ import dynamic from 'next/dynamic';
 const Loader2 = dynamic(() => import('lucide-react').then(mod => ({ default: mod.Loader2 })), { ssr: false });
 const Pencil = dynamic(() => import('lucide-react').then(mod => ({ default: mod.Pencil })), { ssr: false });
 const CpuIcon = dynamic(() => import('lucide-react').then(mod => ({ default: mod.Cpu })), { ssr: false });
+const ChevronRight = dynamic(() => import('lucide-react').then(mod => ({ default: mod.ChevronRight })), { ssr: false });
+const ChevronDown = dynamic(() => import('lucide-react').then(mod => ({ default: mod.ChevronDown })), { ssr: false });
 import { useItems, TreeNode } from '@/lib/hooks';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { useState } from 'react';
-import { ItemDialog } from './ItemDialog';
 import { BacklogItem } from '@/models/backlogItem';
+import { mutate } from 'swr';
+import { http } from '@/lib/api';
 
 const typeColors: { [key: string]: string } = {
   Epic: 'bg-purple-500',
@@ -32,8 +35,16 @@ const stateColors: { [key: string]: string } = {
 // Couleurs pour les statuts des Stories (US/UC)
 const statusColors: { [key: string]: string } = {
   Todo: 'bg-gray-400',
-  Doing: 'bg-yellow-500', 
+  Doing: 'bg-yellow-500',
   Done: 'bg-green-500',
+};
+
+const allowedParent: Record<string, string | null> = {
+  Epic: null,
+  Capability: 'Epic',
+  Feature: 'Capability',
+  US: 'Feature',
+  UC: 'US',
 };
 
 // Fonction pour obtenir la couleur du badge principal selon le type et l'état
@@ -53,11 +64,23 @@ const getStateBadgeColor = (item: TreeNode): string => {
   return 'bg-gray-400';
 };
 
-function Item({ item, onEdit, level = 0 }: { item: TreeNode, onEdit: (item: BacklogItem) => void, level?: number }) {
-  // Construction du tooltip avec infos SAFe
+interface ItemProps {
+  item: TreeNode;
+  onEdit: (item: BacklogItem) => void;
+  level?: number;
+  collapsed: Set<number>;
+  toggle: (id: number) => void;
+  onDragStart: (item: TreeNode) => void;
+  onDrop: (parent: TreeNode | null) => void;
+}
+
+function Item({ item, onEdit, level = 0, collapsed, toggle, onDragStart, onDrop }: ItemProps) {
+  const isCollapsed = collapsed.has(item.id);
+  const hasChildren = item.children && item.children.length > 0;
+
   const getTooltipContent = () => {
     const parts = [`${item.type}: ${item.title}`];
-    
+
     if ((item.type === 'Epic' || item.type === 'Capability') && 'state' in item && item.state) {
       parts.push(`État: ${item.state}`);
     }
@@ -79,22 +102,36 @@ function Item({ item, onEdit, level = 0 }: { item: TreeNode, onEdit: (item: Back
     if ('owner' in item && item.owner) {
       parts.push(`Owner: ${item.owner}`);
     }
-    
+
     return parts.join('\n');
   };
 
   return (
-    <div>
-      <div 
-        className={`flex items-center gap-2 p-2 rounded-md hover:bg-gray-100 cursor-pointer`} 
+    <div
+      draggable
+      onDragStart={() => onDragStart(item)}
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={() => onDrop(item)}
+    >
+      <div
+        className={`flex items-center gap-2 p-2 rounded-md hover:bg-gray-100 cursor-pointer`}
         style={{ paddingLeft: `${level * 20 + 8}px` }}
         title={getTooltipContent()}
       >
+        {hasChildren && (
+          <button
+            onClick={() => toggle(item.id)}
+            aria-label={isCollapsed ? 'Expand' : 'Collapse'}
+            className="p-0 w-4 h-4 text-gray-600"
+          >
+            {isCollapsed ? <ChevronRight className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+          </button>
+        )}
         {/* Badge principal avec couleur selon state/status */}
         <Badge className={`${getBadgeColor(item)} text-white`}>
           {item.type}
         </Badge>
-        
+
         {/* Badge d'état/statut avec couleur spécifique */}
         {((item.type === 'Epic' || item.type === 'Capability') && 'state' in item && item.state) && (
           <Badge className={`${getStateBadgeColor(item)} text-white text-xs`}>
@@ -106,7 +143,7 @@ function Item({ item, onEdit, level = 0 }: { item: TreeNode, onEdit: (item: Back
             {item.status}
           </Badge>
         )}
-        
+
         {/* Badges additionnels pour infos SAFe */}
         <div className="flex gap-1">
           {'wsjf' in item && item.wsjf && (
@@ -125,7 +162,7 @@ function Item({ item, onEdit, level = 0 }: { item: TreeNode, onEdit: (item: Back
             </Badge>
           )}
         </div>
-        
+
         <div className="flex-1 flex items-center gap-2">
           <span>{item.title}</span>
           {item.generated_by_ai && (
@@ -139,15 +176,57 @@ function Item({ item, onEdit, level = 0 }: { item: TreeNode, onEdit: (item: Back
           <Pencil className="h-4 w-4" />
         </Button>
       </div>
-      {item.children?.map((child) => (
-        <Item key={child.id} item={child as TreeNode} onEdit={onEdit} level={level + 1} />
-      ))}
+      {hasChildren && !isCollapsed && (
+        <div onDragOver={(e) => e.preventDefault()} onDrop={() => onDrop(item)}>
+          {item.children?.map((child) => (
+            <Item
+              key={child.id}
+              item={child as TreeNode}
+              onEdit={onEdit}
+              level={level + 1}
+              collapsed={collapsed}
+              toggle={toggle}
+              onDragStart={onDragStart}
+              onDrop={onDrop}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }
 
 export function ItemTree({ projectId, onEdit }: { projectId: number | null, onEdit: (item: BacklogItem) => void }) {
   const { tree, isLoading, error } = useItems(projectId);
+  const [collapsed, setCollapsed] = useState<Set<number>>(new Set());
+  const [dragged, setDragged] = useState<TreeNode | null>(null);
+
+  const toggle = (id: number) => {
+    setCollapsed(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  };
+
+  const handleDrop = async (parent: TreeNode | null) => {
+    if (!dragged) return;
+    if (parent && contains(dragged, parent.id)) return;
+    const parentType = parent ? parent.type : null;
+    if (allowedParent[dragged.type] !== parentType) return;
+    try {
+      await http(`/items/${dragged.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ parent_id: parent ? parent.id : null }),
+      });
+      mutate(`/items?project_id=${projectId}`);
+    } catch (err) {
+      console.error('Move error', err);
+    } finally {
+      setDragged(null);
+    }
+  };
 
   if (isLoading) {
     return (
@@ -162,10 +241,27 @@ export function ItemTree({ projectId, onEdit }: { projectId: number | null, onEd
   }
 
   return (
-    <div className="space-y-1">
+    <div
+      className="space-y-1"
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={() => handleDrop(null)}
+    >
       {tree?.map((item) => (
-        <Item key={item.id} item={item} onEdit={onEdit} />
+        <Item
+          key={item.id}
+          item={item}
+          onEdit={onEdit}
+          collapsed={collapsed}
+          toggle={toggle}
+          onDragStart={setDragged}
+          onDrop={handleDrop}
+        />
       ))}
     </div>
   );
+}
+
+function contains(node: TreeNode, id: number): boolean {
+  if (node.id === id) return true;
+  return node.children?.some(child => contains(child as TreeNode, id)) ?? false;
 }

--- a/frontend/src/components/__tests__/BacklogPane.test.tsx
+++ b/frontend/src/components/__tests__/BacklogPane.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import BacklogPane from '../BacklogPane';
+import { ItemTree } from '../ItemTree';
+
+// Mocks
+vi.mock('@/context/ProjectContext', () => ({
+  useProjects: () => ({ currentProject: { id: 1 } }),
+}));
+
+vi.mock('@/components/ItemDialog', () => ({
+  ItemDialog: () => null,
+}));
+
+vi.mock('next/dynamic', () => ({
+  default: () => () => <svg />,
+}));
+
+const useItemsMock = vi.fn();
+vi.mock('@/lib/hooks', () => ({
+  useItems: (...args: any[]) => useItemsMock(...args),
+}));
+
+const sampleTree: any = [
+  {
+    id: 1,
+    title: 'Epic 1',
+    type: 'Epic',
+    parent_id: null,
+    project_id: 1,
+    description: null,
+    state: 'Backlog',
+    benefit_hypothesis: '',
+    children: [
+      {
+        id: 2,
+        title: 'Capability 1',
+        type: 'Capability',
+        parent_id: 1,
+        project_id: 1,
+        description: null,
+        state: 'Backlog',
+        benefit_hypothesis: '',
+        children: [],
+      },
+    ],
+  },
+];
+
+const sampleData: any = [
+  {
+    id: 1,
+    title: 'Epic 1',
+    type: 'Epic',
+    parent_id: null,
+    project_id: 1,
+    description: null,
+    state: 'Backlog',
+    benefit_hypothesis: '',
+  },
+  {
+    id: 2,
+    title: 'Capability 1',
+    type: 'Capability',
+    parent_id: 1,
+    project_id: 1,
+    description: null,
+    state: 'Backlog',
+    benefit_hypothesis: '',
+  },
+];
+
+beforeEach(() => {
+  useItemsMock.mockReturnValue({ tree: sampleTree, data: sampleData, isLoading: false, error: null });
+});
+
+describe('BacklogPane tabs', () => {
+  it('shows tree view by default', () => {
+    render(<BacklogPane />);
+    expect(screen.getByText('Epic 1')).toBeInTheDocument();
+  });
+
+  it('switches to table view', () => {
+    render(<BacklogPane />);
+    fireEvent.click(screen.getByRole('tab', { name: /Vue Table/i }));
+    expect(screen.getByText('Epic 1')).toBeInTheDocument();
+  });
+
+  it('switches to diagram view', () => {
+    render(<BacklogPane />);
+    fireEvent.click(screen.getByRole('tab', { name: /Vue Diagramme/i }));
+    expect(screen.getByText('Epic 1')).toBeInTheDocument();
+  });
+});
+
+describe('ItemTree edge cases', () => {
+  it('collapses node to hide children', () => {
+    render(<ItemTree projectId={1} onEdit={() => {}} />);
+    const toggle = screen.getByLabelText('Collapse');
+    fireEvent.click(toggle);
+    expect(screen.queryByText('Capability 1')).not.toBeInTheDocument();
+  });
+
+  it('shows loading state', () => {
+    useItemsMock.mockReturnValueOnce({ tree: [], data: [], isLoading: true, error: null });
+    const { container } = render(<ItemTree projectId={1} onEdit={() => {}} />);
+    expect(container.querySelector('svg')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- add BacklogViewTabs component to switch between diagram, tree, and table backlog views
- enhance ItemTree with expand/collapse and drag-and-drop with backend updates
- test tab switching, collapse, and loading states

## Testing
- `cd frontend && pnpm test run`
- `cd frontend && pnpm lint` *(fails: Unexpected any, unused vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a9cb254c8330b937fa64faed434c