### PR TITLE
fix: handle missing run steps

### DIFF
--- a/frontend/src/components/RunTimeline.test.tsx
+++ b/frontend/src/components/RunTimeline.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import RunTimeline from "./RunTimeline";
+
+describe("RunTimeline", () => {
+  const baseRun = { run_id: "1", status: "running" };
+
+  it("renders segments for provided steps", () => {
+    const run = {
+      ...baseRun,
+      steps: [
+        { step: "plan", start: "2024-01-01T00:00:00Z", end: "2024-01-01T00:01:00Z" },
+        { step: "execute", start: "2024-01-01T00:01:00Z", end: "2024-01-01T00:02:00Z" },
+      ],
+    };
+    render(<RunTimeline run={run} />);
+    expect(screen.getByTitle("plan")).toBeInTheDocument();
+    expect(screen.getByTitle("execute")).toBeInTheDocument();
+  });
+
+  it("shows loading skeleton when steps are undefined", () => {
+    render(<RunTimeline run={baseRun as any} />);
+    expect(screen.getByTestId("timeline-loading")).toBeInTheDocument();
+  });
+
+  it("shows loading skeleton when steps array is empty", () => {
+    render(<RunTimeline run={{ ...baseRun, steps: [] }} />);
+    expect(screen.getByTestId("timeline-loading")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/RunTimeline.tsx
+++ b/frontend/src/components/RunTimeline.tsx
@@ -10,7 +10,7 @@ interface Step {
 interface Run {
   run_id: string;
   status: string;
-  steps: Step[];
+  steps?: Step[];
 }
 
 const colors: Record<string, string> = {
@@ -20,19 +20,29 @@ const colors: Record<string, string> = {
 };
 
 export default function RunTimeline({ run }: { run: Run }) {
-  const durations = run.steps.map(s => new Date(s.end).getTime() - new Date(s.start).getTime());
+  const steps = run.steps ?? [];
+  const durations = steps.map(
+    s => new Date(s.end).getTime() - new Date(s.start).getTime(),
+  );
   const total = durations.reduce((a, b) => a + b, 0) || 1;
   return (
     <div className="space-y-1">
       <div className="flex h-2 w-full overflow-hidden rounded">
-        {run.steps.map((s, i) => (
+        {steps.length === 0 ? (
           <div
-            key={s.step}
-            className={`${colors[s.step] || "bg-gray-400"} h-full`}
-            style={{ width: `${(durations[i] / total) * 100}%` }}
-            title={s.step}
+            data-testid="timeline-loading"
+            className="h-full w-full animate-pulse rounded bg-gray-200"
           />
-        ))}
+        ) : (
+          steps.map((s, i) => (
+            <div
+              key={s.step}
+              className={`${colors[s.step] || "bg-gray-400"} h-full`}
+              style={{ width: `${(durations[i] / total) * 100}%` }}
+              title={s.step}
+            />
+          ))
+        )}
       </div>
       <Link href={`/runs/${run.run_id}`} className="text-xs text-blue-500 hover:underline">
         Détails du run


### PR DESCRIPTION
## Summary
- handle `RunTimeline` when `run.steps` is undefined or empty
- add tests for loading skeleton

## Testing
- `pnpm exec vitest run`
- `pnpm lint` *(fails: Unexpected any, unused vars, react/no-unescaped-entities)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e16618688330a82777a63901dab7