### PR TITLE
feat: record and stream run steps

### DIFF
--- a/api/ws.py
+++ b/api/ws.py
@@ -1,31 +1,80 @@
-# api/ws.py
+from __future__ import annotations
+
+import asyncio
+from uuid import uuid4
+
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
-from orchestrator import stream
+
+from orchestrator.core_loop import graph, LoopState, Memory
+from orchestrator import crud, stream
 
 router = APIRouter()
+
 
 @router.websocket("/stream")
 async def stream_chat(ws: WebSocket):
     await ws.accept()
+    run_id: str | None = None
     try:
         payload = await ws.receive_json()
         run_id = payload.get("run_id")
-        if not run_id:
-            await ws.close(code=1008, reason="run_id required")
-            return
-        queue = stream.get(run_id)
-        if queue is None:
-            await ws.close(code=404, reason="unknown run")
-            return
+        objective = payload.get("objective")
+        project_id = payload.get("project_id")
+        loop = asyncio.get_event_loop()
+
+        if run_id:
+            queue = stream.get(run_id)
+            if queue is None:
+                await ws.close(code=404, reason="unknown run")
+                return
+            # discard existing queued steps so only fresh ones are sent
+            try:
+                while True:
+                    queue.get_nowait()
+            except asyncio.QueueEmpty:
+                pass
+        else:
+            if not objective:
+                await ws.close(code=1008, reason="objective required")
+                return
+            run_id = str(uuid4())
+            crud.create_run(run_id, objective, project_id)
+            queue = stream.register(run_id, loop)
+            state = LoopState(
+                objective=objective,
+                project_id=project_id,
+                run_id=run_id,
+                mem_obj=Memory(),
+            )
+            await ws.send_json({"run_id": run_id, "status": "started"})
+
+            async def runner() -> None:
+                try:
+                    async for _ in graph.astream(state):
+                        pass
+                    render = getattr(state, "render", None) or {
+                        "html": "",
+                        "summary": "",
+                    }
+                    crud.finish_run(run_id, render.get("html", ""), render.get("summary", ""))
+                except Exception as exc:  # pragma: no cover - unexpected errors
+                    crud.finish_run(run_id, "", str(exc))
+                finally:
+                    stream.close(run_id)
+
+            asyncio.create_task(runner())
+
         while True:
             chunk = await queue.get()
             if chunk is None:
                 break
             await ws.send_json(chunk)
+        await ws.send_json({"status": "done", "run_id": run_id})
         stream.discard(run_id)
         await ws.close(code=1000)
     except WebSocketDisconnect:
-        pass
-    except Exception as e:
+        if run_id:
+            stream.discard(run_id)
+    except Exception as e:  # pragma: no cover - runtime errors
         msg = (str(e) or "internal error")[:120]
         await ws.close(code=1011, reason=msg)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,4 +54,6 @@ def patch_graph(monkeypatch):
     # Also patch the graph imported in the API module
     import api.main as main
     monkeypatch.setattr(main, "graph", FakeGraph)
+    import api.ws as ws
+    monkeypatch.setattr(ws, "graph", FakeGraph)
 

--- a/tests/test_core_loop.py
+++ b/tests/test_core_loop.py
@@ -1,14 +1,43 @@
 import orchestrator.core_loop as cl
 from orchestrator import crud
+from agents.schemas import Plan, PlanStep
+import types
+from uuid import uuid4
 
 crud.init_db()
 
 def test_loop():
     mem = cl.Memory()
-    from uuid import uuid4
     run_id = str(uuid4())
     objective = "Dire bonjour en français"
     crud.create_run(run_id, objective, None)
     state = cl.LoopState(objective=objective, mem_obj=mem, run_id=run_id)
     out = cl.graph.invoke(state)
     assert "réussie" in out["result"].lower()
+
+
+def test_record_run_step_counts(monkeypatch):
+    run_id = str(uuid4())
+    crud.create_run(run_id, "obj", None)
+
+    plan = Plan(objective="obj", steps=[
+        PlanStep(id=1, title="A", description="d"),
+        PlanStep(id=2, title="B", description="d"),
+    ])
+    monkeypatch.setattr(cl, "make_plan", lambda objective: plan)
+    monkeypatch.setattr(
+        cl.llm_step,
+        "invoke",
+        lambda prompt: types.SimpleNamespace(content="out"),
+    )
+
+    state = cl.LoopState(objective="obj", mem_obj=cl.Memory(), run_id=run_id)
+    out = cl.planner(state)
+    state.plan = out["plan"]
+    exec_out = cl.executor(state)
+    state.exec_result = exec_out["exec_result"]
+    cl.writer(state)
+
+    steps = crud.get_run(run_id)["steps"]
+    assert [s["node"] for s in steps] == ["plan", "execute", "execute", "write"]
+    assert steps[1]["content"].count("A") == 1


### PR DESCRIPTION
## Summary
- include run_id in LoopState and instrument plan/execute/write nodes
- broadcast and persist run steps with order and timestamps
- add WebSocket support to start runs and stream step updates
- simplify /chat endpoint to run synchronously
- cover run step ordering and streaming through tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6e6ffa2708330996b952f0479ec6b