### PR TITLE
fix: refresh run history and handle missing runs

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -20,6 +20,7 @@ export default function Home() {
   const [isLoading, setIsLoading] = useState(false);
   const viewerRef = useRef<any>(null);
   const { currentProject } = useProjects();
+  const [runsRefreshKey, setRunsRefreshKey] = useState(0);
 
   const handleRun = async () => {
     setIsLoading(true);
@@ -31,6 +32,7 @@ export default function Home() {
     });
     const data = await resp.json();
     const runId = data.run_id;
+    setRunsRefreshKey(k => k + 1);
 
     // poll run result
     const poll = async () => {
@@ -47,8 +49,10 @@ export default function Home() {
           },
         ]);
         setIsLoading(false);
+        setRunsRefreshKey(k => k + 1);
       } else if (data.status === "failed") {
         setIsLoading(false);
+        setRunsRefreshKey(k => k + 1);
       } else {
         setTimeout(poll, 1000);
       }
@@ -103,7 +107,7 @@ export default function Home() {
             <BacklogPane />
 
             <HistoryPanel history={history} />
-            <RunsPanel />
+            <RunsPanel refreshKey={runsRefreshKey} />
           </div>
         </main>
       </div>

--- a/frontend/src/app/runs/RunDetail.test.tsx
+++ b/frontend/src/app/runs/RunDetail.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import RunDetail from './[run_id]/page';
+
+vi.mock('@/lib/ws', () => ({
+  connectWS: () => ({
+    send: vi.fn(),
+    close: vi.fn(),
+    onopen: null,
+    onmessage: null,
+    onerror: null,
+  }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+}));
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_API_BASE_URL = 'http://api.test';
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+it('shows run details when run exists', async () => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      run_id: '1',
+      objective: 'test',
+      status: 'running',
+      created_at: new Date().toISOString(),
+      steps: [],
+    }),
+  });
+  render(<RunDetail params={{ run_id: '1' }} />);
+  expect(await screen.findByText('Run 1')).toBeInTheDocument();
+});
+
+it('handles 404 gracefully', async () => {
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: false,
+    status: 404,
+    json: async () => ({}),
+  });
+  render(<RunDetail params={{ run_id: '2' }} />);
+  expect(
+    await screen.findByText('Run not found or has been deleted'),
+  ).toBeInTheDocument();
+  expect(warn).toHaveBeenCalled();
+});

--- a/frontend/src/components/__tests__/RunsPanel.test.tsx
+++ b/frontend/src/components/__tests__/RunsPanel.test.tsx
@@ -25,6 +25,8 @@ afterEach(() => {
 
 it('renders runs when API returns an array', async () => {
   global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
     json: async () => [{ run_id: '1', status: 'ok', steps: [] }],
   });
 
@@ -34,6 +36,8 @@ it('renders runs when API returns an array', async () => {
 
 it('supports object with runs property', async () => {
   global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
     json: async () => ({ runs: [{ run_id: '2', status: 'ok', steps: [] }] }),
   });
 
@@ -48,4 +52,23 @@ it('falls back to empty list on fetch error', async () => {
   await waitFor(() => {
     expect(screen.queryByText('Détails du run')).not.toBeInTheDocument();
   });
+});
+
+it('refetches when refreshKey changes', async () => {
+  const fetchMock = vi.fn().mockImplementation(() => {
+    if (fetchMock.mock.calls.length === 0) {
+      return Promise.resolve({ ok: true, status: 200, json: async () => [] });
+    }
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: async () => [{ run_id: '3', status: 'ok', steps: [] }],
+    });
+  });
+  global.fetch = fetchMock;
+
+  const { rerender } = render(<RunsPanel refreshKey={0} />);
+  rerender(<RunsPanel refreshKey={1} />);
+
+  expect(await screen.findByText('Détails du run')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- refresh runs panel on load and after each run
- show error when a run id is missing
- cover run detail 404 handling with tests

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6ef9b2c6c83308133a310f532b9ed