### PR TITLE
feat: enable intent-driven backlog updates

### DIFF
--- a/orchestrator/intents.py
+++ b/orchestrator/intents.py
@@ -1,0 +1,62 @@
+import re
+from typing import Dict, Optional
+
+ALLOWED_TYPES = {"feature", "epic", "capability", "us", "uc"}
+
+CREATE_KEYWORDS = r"(?:cr[eé]e|cree|ajoute|add|create)"
+UPDATE_KEYWORDS = r"(?:modifie|update|rename|change)"
+TYPE_PATTERN = r"epic|capability|feature|us|uc"
+
+
+def parse_intent(objective: str) -> Optional[Dict]:
+    """Parse a natural language objective into a structured intent.
+
+    Returns a dict describing the intent or ``None`` if no intent could be
+    determined. Supported intents are simple create/update actions on backlog
+    items.
+    """
+    if not objective:
+        return None
+
+    obj_low = objective.lower()
+
+    # --- Create intents -------------------------------------------------
+    if re.search(CREATE_KEYWORDS, obj_low):
+        type_match = re.search(TYPE_PATTERN, obj_low)
+        title_match = re.search(r"[\"']([^\"']+)[\"']", objective)
+        project_match = re.search(r"(?:projet|project)\s*(\d+)", obj_low)
+        parent_match = re.search(
+            r"(?:dans|sous|under)\s+(?:l'|la|le)?(?:epic|capability|feature|us|uc)\s*(\d+)",
+            obj_low,
+        )
+        if not (type_match and title_match and project_match):
+            return None
+        item_type = type_match.group(0).capitalize()
+        return {
+            "action": "create",
+            "type": item_type,
+            "title": title_match.group(1),
+            "project_id": int(project_match.group(1)),
+            "parent_id": int(parent_match.group(1)) if parent_match else None,
+        }
+
+    # --- Update intents -------------------------------------------------
+    if re.search(UPDATE_KEYWORDS, obj_low):
+        id_match = re.search(r"(?:id|item)\s*(\d+)", obj_low)
+        if not id_match:
+            return None
+        fields: Dict[str, str] = {}
+        title_match = re.search(r"(?:titre|title)\s*[\"']([^\"']+)[\"']", objective, re.I)
+        if title_match:
+            fields["title"] = title_match.group(1)
+        desc_match = re.search(r"description\s*[\"']([^\"']+)[\"']", objective, re.I)
+        if desc_match:
+            fields["description"] = desc_match.group(1)
+        status_match = re.search(r"(?:statut|status)\s*([\w-]+)", obj_low)
+        if status_match:
+            fields["status"] = status_match.group(1)
+        if not fields:
+            return None
+        return {"action": "update", "id": int(id_match.group(1)), "fields": fields}
+
+    return None

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -33,6 +33,7 @@ class RunDetail(BaseModel):
     completed_at: datetime | None = None
     html: str | None = None
     summary: str | None = None
+    artifacts: dict | None = None
     steps: list[RunStep] = Field(default_factory=list)
 
 

--- a/tests/test_runs_items.py
+++ b/tests/test_runs_items.py
@@ -1,0 +1,87 @@
+import sqlite3
+import pytest
+from httpx import AsyncClient
+from httpx import ASGITransport
+
+from orchestrator import crud
+from orchestrator.models import ProjectCreate, FeatureCreate, USCreate
+from api.main import app
+
+
+# ---------- DB migration ----------
+
+def test_init_db_adds_artifacts_column(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(crud, "DATABASE_URL", str(db_path))
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE runs (run_id TEXT PRIMARY KEY, project_id INTEGER, objective TEXT, status TEXT, created_at DATETIME, completed_at DATETIME, html TEXT, summary TEXT)"
+    )
+    conn.commit()
+    conn.close()
+    crud.init_db()
+    conn = sqlite3.connect(db_path)
+    cols = [r[1] for r in conn.execute("PRAGMA table_info(runs)")]
+    conn.close()
+    assert "artifacts" in cols
+
+
+# ---------- Chat integration ----------
+
+@pytest.mark.asyncio
+async def test_chat_creates_item_and_artifact(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(crud, "DATABASE_URL", str(db_path))
+    crud.init_db()
+    crud.create_project(ProjectCreate(name="Proj", description=""))
+    transport = ASGITransport(app=app)
+    objective = "Crée la feature 'Canal de vente' pour le projet 1"
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post("/chat", json={"objective": objective})
+        assert resp.status_code == 200
+        run_id = resp.json()["run_id"]
+        run_resp = await ac.get(f"/runs/{run_id}")
+    data = run_resp.json()
+    assert data["artifacts"]["created_item_id"] > 0
+    nodes = [s["node"] for s in data["steps"]]
+    assert "tool:create_item" in nodes
+
+
+@pytest.mark.asyncio
+async def test_chat_invalid_parent_records_error(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(crud, "DATABASE_URL", str(db_path))
+    crud.init_db()
+    crud.create_project(ProjectCreate(name="Proj", description=""))
+    transport = ASGITransport(app=app)
+    objective = "Crée la feature 'Bad' pour le projet 1 dans l'epic 999"
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post("/chat", json={"objective": objective})
+        run_id = resp.json()["run_id"]
+        run_resp = await ac.get(f"/runs/{run_id}")
+    data = run_resp.json()
+    nodes = [s["node"] for s in data["steps"]]
+    assert "error" in nodes
+    assert data["status"] == "done"
+    assert "invalid parent_id" in data["summary"]
+
+
+@pytest.mark.asyncio
+async def test_chat_invalid_hierarchy_records_error(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(crud, "DATABASE_URL", str(db_path))
+    crud.init_db()
+    crud.create_project(ProjectCreate(name="Proj", description=""))
+    feature = crud.create_item(FeatureCreate(title="F", description="", project_id=1, parent_id=None))
+    us = crud.create_item(USCreate(title="U", description="", project_id=1, parent_id=feature.id))
+    transport = ASGITransport(app=app)
+    objective = f"Crée la feature 'Bad' pour le projet 1 dans l'US {us.id}"
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post("/chat", json={"objective": objective})
+        run_id = resp.json()["run_id"]
+        run_resp = await ac.get(f"/runs/{run_id}")
+    data = run_resp.json()
+    nodes = [s["node"] for s in data["steps"]]
+    assert "error" in nodes
+    assert data["status"] == "done"
+    assert "invalid hierarchy" in data["summary"]


### PR DESCRIPTION
## Summary
- handle `artifacts` column in runs table and CRUD
- parse simple create/update intents and execute during /chat
- expose run artifacts and record tool steps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7093408008330b36986817adb7292