### PR TITLE
feat: add rule-based intent handling for chat backlog items

### DIFF
--- a/orchestrator/intents.py
+++ b/orchestrator/intents.py
@@ -1,55 +1,68 @@
+"""Rule based intent parsing used by the /chat endpoint."""
+
+from __future__ import annotations
+
 import re
 from typing import Dict, Optional
 
-ALLOWED_TYPES = {"feature", "epic", "capability", "us", "uc"}
-
-CREATE_KEYWORDS = r"(?:cr[eé]e|cree|ajoute|add|create)"
-UPDATE_KEYWORDS = r"(?:modifie|update|rename|change)"
+# Keywords are deliberately simple; the goal is only to support a handful of
+# deterministic commands for the MVP.
+CREATE_KEYWORDS = r"(?:cr[eé]er?|ajoute?r?|create|add)"
+UPDATE_KEYWORDS = r"(?:modifie?r?|update|rename|change)"
 TYPE_PATTERN = r"epic|capability|feature|us|uc"
 
 
-def parse_intent(objective: str) -> Optional[Dict]:
-    """Parse a natural language objective into a structured intent.
+ALLOWED_TYPES = {"epic", "capability", "feature", "us", "uc"}
 
-    Returns a dict describing the intent or ``None`` if no intent could be
-    determined. Supported intents are simple create/update actions on backlog
-    items.
-    """
+
+def _parse_common(obj: str) -> tuple[Optional[str], Optional[str], Optional[int], Optional[int]]:
+    """Extract basic elements shared by create/update intents."""
+
+    type_match = re.search(TYPE_PATTERN, obj, re.I)
+    item_type = type_match.group(0).capitalize() if type_match else None
+    title_match = re.search(r"['\"]([^'\"]+)['\"]", obj)
+    title = title_match.group(1) if title_match else None
+    project_match = re.search(r"(?:projet|project)\s*(\d+)", obj, re.I)
+    project_id = int(project_match.group(1)) if project_match else None
+    parent_match = re.search(
+        r"(?:dans|sous|under)\s+(?:l'|la|le)?(?:epic|capability|feature|us|uc)\s*(\d+)",
+        obj,
+        re.I,
+    )
+    parent_id = int(parent_match.group(1)) if parent_match else None
+    return item_type, title, project_id, parent_id
+
+
+def parse_intent(objective: str) -> Optional[Dict]:
+    """Parse a natural language objective into a structured intent."""
+
     if not objective:
         return None
 
-    obj_low = objective.lower()
+    obj = objective.strip()
+    obj_low = obj.lower()
 
-    # --- Create intents -------------------------------------------------
+    # ----- Create -----------------------------------------------------
     if re.search(CREATE_KEYWORDS, obj_low):
-        type_match = re.search(TYPE_PATTERN, obj_low)
-        title_match = re.search(r"[\"']([^\"']+)[\"']", objective)
-        project_match = re.search(r"(?:projet|project)\s*(\d+)", obj_low)
-        parent_match = re.search(
-            r"(?:dans|sous|under)\s+(?:l'|la|le)?(?:epic|capability|feature|us|uc)\s*(\d+)",
-            obj_low,
-        )
-        if not (type_match and title_match and project_match):
+        item_type, title, project_id, parent_id = _parse_common(obj)
+        if not (item_type and title):
             return None
-        item_type = type_match.group(0).capitalize()
         return {
             "action": "create",
             "type": item_type,
-            "title": title_match.group(1),
-            "project_id": int(project_match.group(1)),
-            "parent_id": int(parent_match.group(1)) if parent_match else None,
+            "title": title,
+            "project_id": project_id,
+            "parent_id": parent_id,
         }
 
-    # --- Update intents -------------------------------------------------
+    # ----- Update -----------------------------------------------------
     if re.search(UPDATE_KEYWORDS, obj_low):
-        id_match = re.search(r"(?:id|item)\s*(\d+)", obj_low)
-        if not id_match:
-            return None
         fields: Dict[str, str] = {}
-        title_match = re.search(r"(?:titre|title)\s*[\"']([^\"']+)[\"']", objective, re.I)
+        # New title/description/status
+        title_match = re.search(r"(?:titre|title)[^'\"]*['\"]([^'\"]+)['\"]", obj, re.I)
         if title_match:
             fields["title"] = title_match.group(1)
-        desc_match = re.search(r"description\s*[\"']([^\"']+)[\"']", objective, re.I)
+        desc_match = re.search(r"description[^'\"]*['\"]([^'\"]+)['\"]", obj, re.I)
         if desc_match:
             fields["description"] = desc_match.group(1)
         status_match = re.search(r"(?:statut|status)\s*([\w-]+)", obj_low)
@@ -57,6 +70,22 @@ def parse_intent(objective: str) -> Optional[Dict]:
             fields["status"] = status_match.group(1)
         if not fields:
             return None
-        return {"action": "update", "id": int(id_match.group(1)), "fields": fields}
+
+        # Prefer explicit numeric id
+        id_match = re.search(r"(?:epic|capability|feature|us|uc)\s*(\d+)", obj_low)
+        if not id_match:
+            id_match = re.search(r"\b(\d+)\b", obj_low)
+        if id_match:
+            return {"action": "update", "id": int(id_match.group(1)), "fields": fields}
+
+        # Fallback: lookup by type + quoted title
+        item_type, title, project_id, _ = _parse_common(obj)
+        if item_type and title:
+            return {
+                "action": "update",
+                "lookup": {"type": item_type, "title": title, "project_id": project_id},
+                "fields": fields,
+            }
 
     return None
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -35,7 +35,8 @@ async def test_chat_endpoint(monkeypatch):
 
         run = crud.get_run(body["run_id"])
         assert run["status"] == "done"
-        assert len(run["steps"]) == 3
+        # A preliminary plan step is recorded before the core graph runs
+        assert len(run["steps"]) == 4
         r3 = await ac.get(f"/runs?project_id=1")
         assert r3.status_code == 200
 

--- a/tests/test_chat_items.py
+++ b/tests/test_chat_items.py
@@ -1,0 +1,98 @@
+import sqlite3
+import json
+import pytest
+from httpx import AsyncClient
+from httpx import ASGITransport
+
+from api.main import app
+from orchestrator import crud
+from orchestrator.models import ProjectCreate, FeatureCreate
+
+
+# ---------- DB migration ----------
+
+def test_init_db_artifacts_column_idempotent(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(crud, "DATABASE_URL", str(db_path))
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE runs (run_id TEXT PRIMARY KEY, project_id INTEGER, objective TEXT, status TEXT, created_at DATETIME, completed_at DATETIME, html TEXT, summary TEXT)"
+    )
+    conn.commit()
+    conn.close()
+    # First migration adds the column, second call should not fail
+    crud.init_db()
+    crud.init_db()
+    conn = sqlite3.connect(db_path)
+    cols = [r[1] for r in conn.execute("PRAGMA table_info(runs)")]
+    conn.close()
+    assert "artifacts" in cols
+
+
+# ---------- Chat flows ----------
+
+@pytest.mark.asyncio
+async def test_chat_create_flow(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(crud, "DATABASE_URL", str(db_path))
+    crud.init_db()
+    crud.create_project(ProjectCreate(name="Proj", description=""))
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post(
+            "/chat",
+            json={"objective": "Créer la feature 'Canal de vente'", "project_id": 1},
+        )
+        run_id = resp.json()["run_id"]
+        run_resp = await ac.get(f"/runs/{run_id}")
+        items_resp = await ac.get("/api/items", params={"project_id": 1})
+    data = run_resp.json()
+    assert data["status"] == "done"
+    assert data["artifacts"]["created_item_id"] > 0
+    nodes = [s["node"] for s in data["steps"]]
+    assert "tool:create_item" in nodes
+    assert any(it["title"] == "Canal de vente" for it in items_resp.json())
+
+
+@pytest.mark.asyncio
+async def test_chat_update_flow(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(crud, "DATABASE_URL", str(db_path))
+    crud.init_db()
+    crud.create_project(ProjectCreate(name="Proj", description=""))
+    feature = crud.create_item(
+        FeatureCreate(title="Canal de vente", description="", project_id=1, parent_id=None)
+    )
+    transport = ASGITransport(app=app)
+    objective = f"Modifie le titre de la feature {feature.id} en 'Canal de vente v2'"
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post(
+            "/chat",
+            json={"objective": objective, "project_id": 1},
+        )
+        run_id = resp.json()["run_id"]
+        run_resp = await ac.get(f"/runs/{run_id}")
+        item_resp = await ac.get(f"/api/items/{feature.id}")
+    data = run_resp.json()
+    assert data["artifacts"]["updated_item_id"] == feature.id
+    nodes = [s["node"] for s in data["steps"]]
+    assert "tool:update_item" in nodes
+    assert item_resp.json()["title"] == "Canal de vente v2"
+
+
+@pytest.mark.asyncio
+async def test_chat_missing_project_records_error(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(crud, "DATABASE_URL", str(db_path))
+    crud.init_db()
+    crud.create_project(ProjectCreate(name="Proj", description=""))
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post("/chat", json={"objective": "Créer la feature 'X'"})
+        run_id = resp.json()["run_id"]
+        run_resp = await ac.get(f"/runs/{run_id}")
+    data = run_resp.json()
+    nodes = [s["node"] for s in data["steps"]]
+    assert "error" in nodes
+    assert data["status"] == "done"
+    assert "project_id" in data["summary"].lower()


### PR DESCRIPTION
## Summary
- parse create/update backlog instructions via regex
- execute intents in `/chat` and record artifacts/steps
- add tests for chat item creation, updating, and migration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a71b4d948c8330b48f57ed78bb2e7e