### PR TITLE
Use bound tools with ChatOpenAI

### DIFF
--- a/langchain_openai/__init__.py
+++ b/langchain_openai/__init__.py
@@ -2,8 +2,16 @@ class ChatOpenAI:
     def __init__(self, model: str, temperature: float = 0.0):
         self.model = model
         self.temperature = temperature
-    def invoke(self, prompt: str):
+        self._tools = None
+
+    def bind_tools(self, tools):
+        self._tools = tools
+        return self
+
+    def invoke(self, messages):
+        _ = self._tools  # reference stored tools for type checkers
         class Resp:
             def __init__(self):
                 self.content = "stub"
+                self.additional_kwargs = {}
         return Resp()

--- a/orchestrator/core_loop.py
+++ b/orchestrator/core_loop.py
@@ -133,14 +133,14 @@ graph = build_graph()
 # ---------- Tool loop executor ----------
 async def run_chat_tools(objective: str, project_id: int | None, run_id: str, max_tool_calls: int = 6) -> dict:
     """Run a function-calling loop with the LLM."""
-    model = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+    model = ChatOpenAI(model="gpt-4o-mini", temperature=0).bind_tools(TOOLS)
     messages: list[dict[str, str]] = [
         {"role": "system", "content": TOOL_SYSTEM_PROMPT},
         {"role": "user", "content": objective},
     ]
     artifacts: dict[str, list[int]] = {"created_item_ids": [], "updated_item_ids": []}
     for _ in range(max_tool_calls):
-        rsp = model.invoke(messages, tools=TOOLS, tool_choice="auto")
+        rsp = model.invoke(messages)
         tool_calls = rsp.additional_kwargs.get("tool_calls") or []
         if tool_calls:
             tc = tool_calls[0]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,8 +22,9 @@ async def test_ping():
 @pytest.mark.asyncio
 async def test_chat_endpoint(monkeypatch):
     from langchain_openai import ChatOpenAI
-    def fake_invoke(self, messages, tools=None, tool_choice=None):
+    def fake_invoke(self, messages):
         return types.SimpleNamespace(content="done", additional_kwargs={})
+    monkeypatch.setattr(ChatOpenAI, "bind_tools", lambda self, tools: self)
     monkeypatch.setattr(ChatOpenAI, "invoke", fake_invoke)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         r = await ac.post("/chat", json={"objective": "demo", "project_id": 1})

--- a/tests/test_executor_tools.py
+++ b/tests/test_executor_tools.py
@@ -41,8 +41,8 @@ async def test_chat_creates_item(monkeypatch, tmp_path):
         ),
         types.SimpleNamespace(content="done", additional_kwargs={}),
     ]
-
-    monkeypatch.setattr(ChatOpenAI, "invoke", lambda self, messages, tools=None, tool_choice=None: calls.pop(0))
+    monkeypatch.setattr(ChatOpenAI, "bind_tools", lambda self, tools: self)
+    monkeypatch.setattr(ChatOpenAI, "invoke", lambda self, messages: calls.pop(0))
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
@@ -88,7 +88,8 @@ async def test_chat_updates_item(monkeypatch, tmp_path):
         ),
         types.SimpleNamespace(content="done", additional_kwargs={}),
     ]
-    monkeypatch.setattr(ChatOpenAI, "invoke", lambda self, messages, tools=None, tool_choice=None: calls.pop(0))
+    monkeypatch.setattr(ChatOpenAI, "bind_tools", lambda self, tools: self)
+    monkeypatch.setattr(ChatOpenAI, "invoke", lambda self, messages: calls.pop(0))
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
@@ -115,7 +116,7 @@ async def test_chat_max_tool_calls(monkeypatch, tmp_path):
     crud.create_project(ProjectCreate(name="Proj", description=""))
 
     from langchain_openai import ChatOpenAI
-    def fake_invoke(self, messages, tools=None, tool_choice=None):
+    def fake_invoke(self, messages):
         return types.SimpleNamespace(
             content="",
             additional_kwargs={
@@ -137,6 +138,7 @@ async def test_chat_max_tool_calls(monkeypatch, tmp_path):
                 ]
             },
         )
+    monkeypatch.setattr(ChatOpenAI, "bind_tools", lambda self, tools: self)
     monkeypatch.setattr(ChatOpenAI, "invoke", fake_invoke)
 
     transport = ASGITransport(app=app)
@@ -187,7 +189,8 @@ async def test_handler_error(monkeypatch, tmp_path):
         ),
         types.SimpleNamespace(content="Invalid parent", additional_kwargs={}),
     ]
-    monkeypatch.setattr(ChatOpenAI, "invoke", lambda self, messages, tools=None, tool_choice=None: calls.pop(0))
+    monkeypatch.setattr(ChatOpenAI, "bind_tools", lambda self, tools: self)
+    monkeypatch.setattr(ChatOpenAI, "invoke", lambda self, messages: calls.pop(0))
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:


### PR DESCRIPTION
## Summary
- bind tools to ChatOpenAI model and simplify invoke usage
- extend local ChatOpenAI stub with bind_tools and updated invoke
- adjust API and executor tool tests for bound model calls

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a72fe758048330a00306e24276fb1d