### PR TITLE
feat: enhance chat CRUD intents and tooling

### DIFF
--- a/agents/tools.py
+++ b/agents/tools.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Callable, Awaitable
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ValidationError, field_validator
 
 from orchestrator import crud
 from orchestrator.models import (
@@ -76,18 +76,56 @@ TOOLS = [create_item_spec, update_item_spec, find_item_spec]
 # Helpers
 # ---------------------------------------------------------------------------
 
+class ParentRef(BaseModel):
+    """Reference to a parent item by type and title."""
+
+    type: str
+    title: str
+
+
 class _CreateArgs(BaseModel):
+    """Arguments accepted by ``create_item_tool``.
+
+    ``parent`` is resolved by title/type; ``parent_id`` is kept for backward
+    compatibility with existing tests/tools.
+    """
+
     title: str
     type: str
     project_id: int
+    description: str | None = None
     parent_id: int | None = None
+    parent: ParentRef | None = None
 
-class _UpdateArgs(BaseModel):
-    id: int
+    @field_validator("type")
+    @classmethod
+    def _normalise_type(cls, v: str) -> str:
+        return v.upper() if v.lower() in {"us", "uc"} else v.capitalize()
+
+class LookupRef(BaseModel):
+    """Lookup reference used when updating without explicit id."""
+
+    type: str
+    title: str
+    project_id: int
+
+    @field_validator("type")
+    @classmethod
+    def _normalise_type(cls, v: str) -> str:
+        return v.upper() if v.lower() in {"us", "uc"} else v.capitalize()
+
+
+class UpdateFields(BaseModel):
     title: str | None = None
     description: str | None = None
     status: str | None = None
     parent_id: int | None = None
+
+
+class _UpdateArgs(BaseModel):
+    id: int | None = None
+    lookup: LookupRef | None = None
+    fields: UpdateFields
 
 class _FindArgs(BaseModel):
     query: str
@@ -114,22 +152,42 @@ _MODEL_MAP = {
 # ---------------------------------------------------------------------------
 
 async def create_item_tool(args: Dict[str, Any]) -> Dict[str, Any]:
-    """Validate args and create a backlog item."""
+    """Validate args and create a backlog item.
+
+    ``parent`` can be provided instead of ``parent_id`` and will be resolved by
+    title and type within the given project.  When multiple matches are found,
+    an ``parent_ambiguous`` error is returned so the caller can clarify.
+    """
+
     try:
         data = _CreateArgs(**args)
-        if data.parent_id is not None:
-            parent = crud.get_item(data.parent_id)
+        parent_id = data.parent_id
+        # Resolve parent if given as reference
+        if data.parent is not None:
+            items = crud.get_items(data.project_id, type=data.parent.type)
+            matches = [
+                it for it in items if it.title.lower() == data.parent.title.lower()
+            ]
+            if not matches:
+                return {"ok": False, "error": "parent_not_found"}
+            if len(matches) > 1:
+                return {"ok": False, "error": "parent_ambiguous"}
+            parent_id = matches[0].id
+
+        if parent_id is not None:
+            parent = crud.get_item(parent_id)
             if not parent or parent.project_id != data.project_id:
                 raise ValueError("invalid parent_id")
             allowed = _ALLOWED_PARENT.get(data.type, [])
             if parent.type not in allowed:
                 raise ValueError("invalid hierarchy")
+
         Model = _MODEL_MAP[data.type]
         item = Model(
             title=data.title,
-            description="",
+            description=data.description or "",
             project_id=data.project_id,
-            parent_id=data.parent_id,
+            parent_id=parent_id,
         )
         created = crud.create_item(item)
         return {
@@ -142,13 +200,65 @@ async def create_item_tool(args: Dict[str, Any]) -> Dict[str, Any]:
         return {"ok": False, "error": str(e)}
 
 async def update_item_tool(args: Dict[str, Any]) -> Dict[str, Any]:
-    """Validate args & existence; update item."""
+    """Validate args & existence; update item.
+
+    Supports targeting an item either by explicit ``id`` or by a lookup
+    (``type`` + ``title`` + ``project_id``).  Updates are passed through to the
+    CRUD layer after validating hierarchy rules.
+    """
+
     try:
+        # Backward compatibility: allow id/fields at top-level
+        if "fields" not in args:
+            lookup = None
+            if args.get("id") is None and {
+                "type",
+                "title",
+                "project_id",
+            }.issubset(args):
+                lookup = {
+                    "type": args["type"],
+                    "title": args["title"],
+                    "project_id": args["project_id"],
+                }
+                fields = {
+                    k: v
+                    for k, v in args.items()
+                    if k not in {"id", "type", "title", "project_id", "lookup"}
+                }
+            else:
+                fields = {
+                    k: v
+                    for k, v in args.items()
+                    if k not in {"id", "type", "project_id", "lookup"}
+                }
+            args = {"id": args.get("id"), "lookup": lookup, "fields": fields}
+
         data = _UpdateArgs(**args)
-        item = crud.get_item(data.id)
+
+        item_id = data.id
+        if item_id is None:
+            # Resolve via lookup
+            items = crud.get_items(
+                data.lookup.project_id, type=data.lookup.type
+            )
+            matches = [
+                it
+                for it in items
+                if it.title.lower() == data.lookup.title.lower()
+            ]
+            if not matches:
+                return {"ok": False, "error": "item_not_found"}
+            if len(matches) > 1:
+                return {"ok": False, "error": "item_ambiguous"}
+            item_id = matches[0].id
+
+        item = crud.get_item(item_id)
         if not item:
             raise ValueError("item not found")
-        update_data = data.model_dump(exclude={"id"}, exclude_none=True)
+
+        update_data = data.fields.model_dump(exclude_none=True)
+
         if "parent_id" in update_data:
             new_parent_id = update_data["parent_id"]
             if new_parent_id is not None:
@@ -158,15 +268,21 @@ async def update_item_tool(args: Dict[str, Any]) -> Dict[str, Any]:
                 allowed = _ALLOWED_PARENT.get(item.type, [])
                 if new_parent.type not in allowed or new_parent.id == item.id:
                     raise ValueError("invalid hierarchy")
-                # detect cycles
                 current = new_parent
                 while current.parent_id is not None:
-                    if current.parent_id == item.id:
+                    if current.parent_id == item_id:
                         raise ValueError("cycle detected")
                     current = crud.get_item(current.parent_id)
                     if current is None:
                         break
-        updated = crud.update_item(data.id, BacklogItemUpdate(**update_data))
+
+        if "status" in update_data and item.type in {"US", "UC"}:
+            if update_data["status"] not in {"Todo", "Doing", "Done"}:
+                raise ValueError("invalid status")
+        elif "status" in update_data and item.type not in {"US", "UC"}:
+            raise ValueError("invalid status")
+
+        updated = crud.update_item(item_id, BacklogItemUpdate(**update_data))
         return {
             "ok": True,
             "item_id": updated.id,

--- a/api/main.py
+++ b/api/main.py
@@ -4,8 +4,16 @@ from api.ws import router as ws_router
 import json
 from importlib import metadata
 from datetime import datetime
+from uuid import uuid4
+
 from orchestrator import crud
-from api.orchestrator import execute_objective
+from orchestrator.intents import (
+    parse_intent,
+    intent_detected,
+    intent_error,
+)
+from agents.tools import create_item_tool, update_item_tool
+from orchestrator.core_loop import run_chat_tools
 from orchestrator.models import (
     ProjectCreate,
     BacklogItemCreate,
@@ -83,12 +91,96 @@ async def health():
 async def ping():
     return {"status": "ok"}
 
-@app.post("/chat", response_model=RunDetail)
-async def chat(payload: dict):
+@app.post("/chat")
+async def chat(payload: dict) -> dict:
+    """Handle a chat objective and perform deterministic CRUD actions when possible."""
+
     objective = payload.get("objective", "")
     project_id = payload.get("project_id")
-    run = execute_objective(None, project_id, objective)
-    return run
+
+    run_id = str(uuid4())
+    crud.create_run(run_id, objective, project_id)
+    crud.record_run_step(run_id, "plan", json.dumps({"objective": objective}))
+
+    artifacts = {"created_item_ids": [], "updated_item_ids": []}
+
+    intent = parse_intent(objective)
+    if intent:
+        intent_detected(run_id, intent)
+    else:
+        # Unknown intent: fall back to graph-based executor
+        intent_error(run_id, "unhandled_objective")
+        await run_chat_tools(objective, project_id, run_id)
+        run = crud.get_run(run_id)
+        return {"run_id": run_id, "html": run.get("html")}
+
+    # Intent-specific processing
+    if intent["action"] == "create":
+        if project_id is None:
+            intent_error(run_id, "missing_project_id")
+            summary = "project_id required"
+            crud.finish_run(run_id, "<p>project_id required</p>", summary, artifacts)
+            return {"run_id": run_id, "html": "<p>project_id required</p>"}
+        args = {
+            "title": intent["title"],
+            "type": intent["type"],
+            "project_id": project_id,
+        }
+        if intent.get("parent"):
+            args["parent"] = intent["parent"]
+        if intent.get("description"):
+            args["description"] = intent["description"]
+        res = await create_item_tool(args)
+        if res.get("ok"):
+            crud.record_run_step(run_id, "tool:create_item", json.dumps(res))
+            artifacts["created_item_ids"].append(res["item_id"])
+            html = (
+                f"<p>Created {res['type']} “{res['title']}” (id {res['item_id']}).</p>"
+            )
+            summary = f"Created {res['type']} #{res['item_id']}"
+            crud.finish_run(run_id, html, summary, artifacts)
+            return {"run_id": run_id, "html": html}
+        else:
+            crud.record_run_step(run_id, "error", json.dumps(res))
+            html = f"<p>{res['error']}</p>"
+            crud.finish_run(run_id, html, res["error"], artifacts)
+            return {"run_id": run_id, "html": html}
+
+    if intent["action"] == "update":
+        target = intent.get("target", {})
+        args: dict = {"fields": intent.get("fields", {})}
+        if target.get("id") is not None:
+            args["id"] = target["id"]
+        else:
+            if project_id is None and target.get("project_id") is None:
+                intent_error(run_id, "missing_project_id")
+                html = "<p>project_id required</p>"
+                crud.finish_run(run_id, html, "project_id required", artifacts)
+                return {"run_id": run_id, "html": html}
+            args["lookup"] = {
+                "type": target["type"],
+                "title": target["title"],
+                "project_id": target.get("project_id") or project_id,
+            }
+        res = await update_item_tool(args)
+        if res.get("ok"):
+            crud.record_run_step(run_id, "tool:update_item", json.dumps(res))
+            artifacts["updated_item_ids"].append(res["item_id"])
+            html = f"<p>Updated item {res['item_id']}.</p>"
+            summary = f"Updated item #{res['item_id']}"
+            crud.finish_run(run_id, html, summary, artifacts)
+            return {"run_id": run_id, "html": html}
+        else:
+            crud.record_run_step(run_id, "error", json.dumps(res))
+            html = f"<p>{res['error']}</p>"
+            crud.finish_run(run_id, html, res["error"], artifacts)
+            return {"run_id": run_id, "html": html}
+
+    # Should not reach here
+    intent_error(run_id, "unhandled_objective")
+    await run_chat_tools(objective, project_id, run_id)
+    run = crud.get_run(run_id)
+    return {"run_id": run_id, "html": run.get("html")}
 
 
 @app.get("/runs/{run_id}", response_model=RunDetail)

--- a/orchestrator/intents.py
+++ b/orchestrator/intents.py
@@ -1,91 +1,127 @@
 """Rule based intent parsing used by the /chat endpoint."""
-
 from __future__ import annotations
 
+import json
 import re
 from typing import Dict, Optional
+
+from orchestrator import crud
 
 # Keywords are deliberately simple; the goal is only to support a handful of
 # deterministic commands for the MVP.
 CREATE_KEYWORDS = r"(?:cr[eé]er?|ajoute?r?|create|add)"
-UPDATE_KEYWORDS = r"(?:modifie?r?|update|rename|change)"
+UPDATE_KEYWORDS = r"(?:modifie?r?|update|rename|renomm(?:e|er)?|change)"
 TYPE_PATTERN = r"epic|capability|feature|us|uc"
 
 
-ALLOWED_TYPES = {"epic", "capability", "feature", "us", "uc"}
-
-
-def _parse_common(obj: str) -> tuple[Optional[str], Optional[str], Optional[int], Optional[int]]:
-    """Extract basic elements shared by create/update intents."""
-
-    type_match = re.search(TYPE_PATTERN, obj, re.I)
-    item_type = type_match.group(0).capitalize() if type_match else None
-    title_match = re.search(r"['\"]([^'\"]+)['\"]", obj)
-    title = title_match.group(1) if title_match else None
-    project_match = re.search(r"(?:projet|project)\s*(\d+)", obj, re.I)
-    project_id = int(project_match.group(1)) if project_match else None
-    parent_match = re.search(
-        r"(?:dans|sous|under)\s+(?:l'|la|le)?(?:epic|capability|feature|us|uc)\s*(\d+)",
-        obj,
-        re.I,
-    )
-    parent_id = int(parent_match.group(1)) if parent_match else None
-    return item_type, title, project_id, parent_id
+def _norm_type(raw: str) -> str:
+    return raw.upper() if raw.lower() in {"us", "uc"} else raw.capitalize()
 
 
 def parse_intent(objective: str) -> Optional[Dict]:
     """Parse a natural language objective into a structured intent."""
-
     if not objective:
         return None
-
     obj = objective.strip()
     obj_low = obj.lower()
 
     # ----- Create -----------------------------------------------------
     if re.search(CREATE_KEYWORDS, obj_low):
-        item_type, title, project_id, parent_id = _parse_common(obj)
-        if not (item_type and title):
+        type_match = re.search(TYPE_PATTERN, obj_low)
+        if not type_match:
             return None
+        item_type = _norm_type(type_match.group(0))
+        title_match = re.search(r"['\"]([^'\"]+)['\"]", obj)
+        title = title_match.group(1) if title_match else None
+        if not title:
+            return None
+        parent = None
+        parent_match = re.search(
+            rf"(?:sous|under)\s+(?:l'|la|le)?\s*({TYPE_PATTERN})\s*['\"]([^'\"]+)['\"]",
+            obj,
+            re.I,
+        )
+        if parent_match:
+            parent = {"type": _norm_type(parent_match.group(1)), "title": parent_match.group(2)}
+        desc_match = re.search(
+            r"(?:avec description|with description)\s*: ?['\"]([^'\"]+)['\"]",
+            obj,
+            re.I,
+        )
+        description = desc_match.group(1) if desc_match else None
         return {
             "action": "create",
             "type": item_type,
             "title": title,
-            "project_id": project_id,
-            "parent_id": parent_id,
+            "parent": parent,
+            "description": description,
         }
 
     # ----- Update -----------------------------------------------------
     if re.search(UPDATE_KEYWORDS, obj_low):
         fields: Dict[str, str] = {}
-        # New title/description/status
-        title_match = re.search(r"(?:titre|title)[^'\"]*['\"]([^'\"]+)['\"]", obj, re.I)
+        # New title
+        title_match = re.search(r"renomm[eé]?[^'\"]*['\"]([^'\"]+)['\"]", obj, re.I)
+        if not title_match:
+            title_match = re.search(
+                r"(?:title|titre)[^'\"]*(?:to|en)\s*['\"]([^'\"]+)['\"]",
+                obj,
+                re.I,
+            )
         if title_match:
             fields["title"] = title_match.group(1)
-        desc_match = re.search(r"description[^'\"]*['\"]([^'\"]+)['\"]", obj, re.I)
+        desc_match = re.search(
+            r"description[^'\"]*(?:to|en|:)\s*['\"]([^'\"]+)['\"]",
+            obj,
+            re.I,
+        )
         if desc_match:
             fields["description"] = desc_match.group(1)
-        status_match = re.search(r"(?:statut|status)\s*([\w-]+)", obj_low)
+        status_match = re.search(
+            r"(?:status|statut)[^\w]*?(?:to|en|:)?\s*['\"]?([\w-]+)['\"]?",
+            obj,
+            re.I,
+        )
         if status_match:
             fields["status"] = status_match.group(1)
         if not fields:
             return None
 
-        # Prefer explicit numeric id
-        id_match = re.search(r"(?:epic|capability|feature|us|uc)\s*(\d+)", obj_low)
+        id_match = re.search(rf"(?:{TYPE_PATTERN})\s*(\d+)", obj_low)
         if not id_match:
             id_match = re.search(r"\b(\d+)\b", obj_low)
         if id_match:
-            return {"action": "update", "id": int(id_match.group(1)), "fields": fields}
-
-        # Fallback: lookup by type + quoted title
-        item_type, title, project_id, _ = _parse_common(obj)
-        if item_type and title:
+            return {"action": "update", "target": {"id": int(id_match.group(1))}, "fields": fields}
+        lookup_match = re.search(rf"({TYPE_PATTERN})\s*['\"]([^'\"]+)['\"]", obj, re.I)
+        if lookup_match:
+            project_match = re.search(r"(?:projet|project)\s*(\d+)", obj, re.I)
+            project_id = int(project_match.group(1)) if project_match else None
             return {
                 "action": "update",
-                "lookup": {"type": item_type, "title": title, "project_id": project_id},
+                "target": {
+                    "type": _norm_type(lookup_match.group(1)),
+                    "title": lookup_match.group(2),
+                    "project_id": project_id,
+                },
                 "fields": fields,
             }
 
     return None
 
+
+# ---------------------------------------------------------------------------
+# Helpers to record intent steps
+# ---------------------------------------------------------------------------
+
+
+def intent_detected(run_id: str, intent: Dict) -> None:
+    """Record a successful intent detection step."""
+    crud.record_run_step(run_id, "intent_detected", json.dumps(intent))
+
+
+def intent_error(run_id: str, error: str, detail: Dict | None = None) -> None:
+    """Record an intent parsing error."""
+    payload = {"error": error}
+    if detail:
+        payload.update(detail)
+    crud.record_run_step(run_id, "intent_error", json.dumps(payload))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -34,7 +34,8 @@ async def test_chat_endpoint(monkeypatch):
 
         run = crud.get_run(body["run_id"])
         assert run["status"] == "done"
-        assert len(run["steps"]) == 1  # only plan step
+        # plan step + intent_error because objective is unhandled
+        assert len(run["steps"]) == 2
         r3 = await ac.get(f"/runs?project_id=1")
         assert r3.status_code == 200
 

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -20,13 +20,16 @@ async def test_chat_creates_feature():
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.post(
-            "/chat", json={"objective": "Crée la feature entête", "project_id": project.id}
+            "/chat",
+            json={"objective": "Créer la feature 'Accueil'", "project_id": project.id},
         )
-    assert resp.status_code == 200
-    data = resp.json()
-    created = data["artifacts"]["created_item_ids"]
+        assert resp.status_code == 200
+        run_id = resp.json()["run_id"]
+        run = await ac.get(f"/runs/{run_id}")
+    run_data = run.json()
+    created = run_data["artifacts"]["created_item_ids"]
     assert len(created) == 1
     feature = crud.get_item(created[0])
     assert feature is not None
-    assert feature.title == "Crée la feature entête"
+    assert feature.title == "Accueil"
     assert feature.type == "Feature"

--- a/tests/test_chat_intents.py
+++ b/tests/test_chat_intents.py
@@ -1,0 +1,139 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from api.main import app
+from orchestrator import crud
+from orchestrator.models import ProjectCreate, FeatureCreate, USCreate
+
+
+def reset_db():
+    crud.init_db()
+    conn = crud.get_db_connection()
+    conn.execute("DELETE FROM run_steps")
+    conn.execute("DELETE FROM runs")
+    conn.execute("DELETE FROM backlog")
+    conn.execute("DELETE FROM projects")
+    conn.commit()
+    conn.close()
+
+
+@pytest.mark.asyncio
+async def test_create_feature_and_run_steps():
+    reset_db()
+    project = crud.create_project(ProjectCreate(name="P", description=""))
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post(
+            "/chat",
+            json={"objective": "Créer la feature 'Accueil'", "project_id": project.id},
+        )
+        run_id = resp.json()["run_id"]
+        run = (await ac.get(f"/runs/{run_id}")).json()
+    assert any(s["node"] == "tool:create_item" for s in run["steps"])
+    assert run["artifacts"]["created_item_ids"]
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        items_resp = await ac.get(f"/api/items?project_id={project.id}")
+    items = items_resp.json()
+    assert any(it["title"] == "Accueil" and it["type"] == "Feature" for it in items)
+
+
+@pytest.mark.asyncio
+async def test_create_us_under_feature():
+    reset_db()
+    project = crud.create_project(ProjectCreate(name="P", description=""))
+    parent = crud.create_item(FeatureCreate(title="Checkout", description="", project_id=project.id, parent_id=None))
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post(
+            "/chat",
+            json={"objective": "Créer la US 'payer par carte' sous la Feature 'Checkout'", "project_id": project.id},
+        )
+        run_id = resp.json()["run_id"]
+        run = (await ac.get(f"/runs/{run_id}")).json()
+    us_id = run["artifacts"]["created_item_ids"][0]
+    us = crud.get_item(us_id)
+    assert us.parent_id == parent.id
+
+
+@pytest.mark.asyncio
+async def test_update_feature_by_id():
+    reset_db()
+    project = crud.create_project(ProjectCreate(name="P", description=""))
+    feat = crud.create_item(FeatureCreate(title="Home", description="", project_id=project.id, parent_id=None))
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post(
+            "/chat",
+            json={"objective": f"Renomme la feature {feat.id} en 'Accueil v2'", "project_id": project.id},
+        )
+        run_id = resp.json()["run_id"]
+        run = (await ac.get(f"/runs/{run_id}")).json()
+    assert feat.id in run["artifacts"]["updated_item_ids"]
+    updated = crud.get_item(feat.id)
+    assert updated.title == "Accueil v2"
+
+
+@pytest.mark.asyncio
+async def test_update_by_lookup_and_ambiguous_error():
+    reset_db()
+    project = crud.create_project(ProjectCreate(name="P", description=""))
+    crud.create_item(FeatureCreate(title="Foo", description="", project_id=project.id, parent_id=None))
+    crud.create_item(FeatureCreate(title="Foo", description="", project_id=project.id, parent_id=None))
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post(
+            "/chat",
+            json={"objective": "Update Feature 'Foo' title to 'Bar'", "project_id": project.id},
+        )
+        run_id = resp.json()["run_id"]
+        run = (await ac.get(f"/runs/{run_id}")).json()
+    assert run["artifacts"]["updated_item_ids"] == []
+    assert any(s["node"] == "error" for s in run["steps"])
+
+
+@pytest.mark.asyncio
+async def test_missing_project_id_error():
+    reset_db()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post(
+            "/chat", json={"objective": "Créer la feature 'Oops'"}
+        )
+        run_id = resp.json()["run_id"]
+        run = (await ac.get(f"/runs/{run_id}")).json()
+    assert any(s["node"] == "intent_error" for s in run["steps"])
+    assert run["artifacts"]["created_item_ids"] == []
+
+
+@pytest.mark.asyncio
+async def test_parent_not_found():
+    reset_db()
+    project = crud.create_project(ProjectCreate(name="P", description=""))
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post(
+            "/chat",
+            json={"objective": "Créer la US 'Test' sous la Feature 'Inexistante'", "project_id": project.id},
+        )
+        run_id = resp.json()["run_id"]
+        run = (await ac.get(f"/runs/{run_id}")).json()
+    assert run["artifacts"]["created_item_ids"] == []
+    assert any(s["node"] == "error" for s in run["steps"])
+
+
+@pytest.mark.asyncio
+async def test_invalid_status_error():
+    reset_db()
+    project = crud.create_project(ProjectCreate(name="P", description=""))
+    us = crud.create_item(USCreate(title="Login", description="", project_id=project.id, parent_id=None))
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post(
+            "/chat",
+            json={"objective": f"Change status of US {us.id} to Invalid", "project_id": project.id},
+        )
+        run_id = resp.json()["run_id"]
+        run = (await ac.get(f"/runs/{run_id}")).json()
+    assert run["artifacts"]["updated_item_ids"] == []
+    assert any(s["node"] == "error" for s in run["steps"])


### PR DESCRIPTION
## Summary
- expand intent parser for create/update with parent linking and FR/EN support
- add robust CRUD tools resolving items by title or id
- integrate deterministic tool-first flow into /chat endpoint with artifacts tracking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7393d8a20833091520c11018621a1