### PR TITLE
Record tool request and response steps in run stream

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -97,7 +97,93 @@ async def test_ws_stream_existing_run_only_new_steps():
             msg = await ws.receive_json()
             assert msg["node"] == "after"
             done = await ws.receive_json()
-            assert done["status"] == "done" and done["run_id"] == run_id
+    assert done["status"] == "done" and done["run_id"] == run_id
+
+
+@pytest.mark.asyncio
+async def test_ws_stream_tool_steps(monkeypatch, tmp_path):
+    from uuid import uuid4
+    import types, json
+    from langchain_openai import ChatOpenAI
+    from orchestrator import stream as run_stream
+    from orchestrator.core_loop import run_chat_tools
+    from orchestrator.models import ProjectCreate
+
+    db = tmp_path / "db.sqlite"
+    monkeypatch.setattr(crud, "DATABASE_URL", str(db))
+    crud.init_db()
+    crud.create_project(ProjectCreate(name="P", description=""))
+
+    calls = [
+        types.SimpleNamespace(
+            content="",
+            additional_kwargs={
+                "tool_calls": [
+                    {
+                        "id": "1",
+                        "type": "function",
+                        "function": {
+                            "name": "create_item",
+                            "arguments": json.dumps({
+                                "title": "Feat",
+                                "type": "Feature",
+                                "project_id": 1,
+                            }),
+                        },
+                    }
+                ]
+            },
+        ),
+        types.SimpleNamespace(
+            content="",
+            additional_kwargs={
+                "tool_calls": [
+                    {
+                        "id": "2",
+                        "type": "function",
+                        "function": {
+                            "name": "update_item",
+                            "arguments": json.dumps({"id": 1, "title": "Feat v2"}),
+                        },
+                    }
+                ]
+            },
+        ),
+        types.SimpleNamespace(content="done", additional_kwargs={}),
+    ]
+    monkeypatch.setattr(ChatOpenAI, "bind_tools", lambda self, tools: self)
+    monkeypatch.setattr(ChatOpenAI, "invoke", lambda self, messages: calls.pop(0))
+
+    run_id = str(uuid4())
+    crud.create_run(run_id, "multi", 1)
+    run_stream.register(run_id, asyncio.get_event_loop())
+
+    async def runner():
+        await run_chat_tools("multi", 1, run_id)
+        run_stream.close(run_id)
+
+    task = asyncio.create_task(runner())
+
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        async with aconnect_ws("http://test/stream", ac) as ws:
+            await ws.send_json({"run_id": run_id})
+            steps = []
+            while True:
+                msg = await ws.receive_json()
+                if msg.get("status") == "done":
+                    break
+                steps.append(msg)
+
+    await task
+    nodes = [s["node"] for s in steps]
+    assert nodes == [
+        "tool:create_item:request",
+        "tool:create_item:response",
+        "tool:update_item:request",
+        "tool:update_item:response",
+    ]
+    timestamps = [s.get("timestamp") for s in steps]
+    assert all(timestamps) and timestamps == sorted(timestamps)
 
 
 @pytest.mark.asyncio

--- a/tests/test_chat_intents.py
+++ b/tests/test_chat_intents.py
@@ -34,7 +34,7 @@ async def test_create_feature_and_run_steps():
         )
         run_id = resp.json()["run_id"]
         run = (await ac.get(f"/runs/{run_id}")).json()
-    assert any(s["node"] == "tool:create_item" for s in run["steps"])
+    assert any(s["node"] == "tool:create_item:response" for s in run["steps"])
     assert run["artifacts"]["created_item_ids"]
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:

--- a/tests/test_executor_tools.py
+++ b/tests/test_executor_tools.py
@@ -52,7 +52,8 @@ async def test_chat_creates_item(monkeypatch, tmp_path):
     run = crud.get_run(run_id)
     assert run["artifacts"]["created_item_ids"][0] > 0
     nodes = [s["node"] for s in run["steps"]]
-    assert "tool:create_item" in nodes
+    assert "tool:create_item:request" in nodes
+    assert "tool:create_item:response" in nodes
     items = crud.get_items(project_id=1)
     assert any(it.title == "Canal de vente" for it in items)
 
@@ -94,7 +95,8 @@ async def test_chat_updates_item(monkeypatch, tmp_path):
     run = crud.get_run(run_id)
     assert run["artifacts"]["updated_item_ids"][0] == feature.id
     nodes = [s["node"] for s in run["steps"]]
-    assert "tool:update_item" in nodes
+    assert "tool:update_item:request" in nodes
+    assert "tool:update_item:response" in nodes
     item = crud.get_item(feature.id)
     assert item.title == "Canal v2"
 
@@ -139,7 +141,8 @@ async def test_chat_max_tool_calls(monkeypatch, tmp_path):
     await run_chat_tools("loop", 1, run_id)
     run = crud.get_run(run_id)
     nodes = [s["node"] for s in run["steps"]]
-    assert nodes.count("tool:create_item") == 10
+    assert nodes.count("tool:create_item:request") == 10
+    assert nodes.count("tool:create_item:response") == 10
     assert "error" in nodes
     assert "max tool calls" in run["summary"].lower()
 
@@ -186,7 +189,8 @@ async def test_handler_error(monkeypatch, tmp_path):
     await run_chat_tools("bad parent", 1, run_id)
     run = crud.get_run(run_id)
     nodes = [s["node"] for s in run["steps"]]
-    assert "tool:create_item" in nodes
+    assert "tool:create_item:request" in nodes
+    assert "tool:create_item:response" in nodes
     assert "error" in nodes
     assert "invalid parent" in run["summary"].lower()
 
@@ -237,7 +241,8 @@ async def test_tool_timeout(monkeypatch, tmp_path):
     await run_chat_tools("slow", 1, run_id)
     run = crud.get_run(run_id)
     nodes = [s["node"] for s in run["steps"]]
-    assert "tool:create_item" in nodes
+    assert "tool:create_item:request" in nodes
+    assert "tool:create_item:response" in nodes
     assert "error" in nodes
     assert run["artifacts"]["created_item_ids"] == []
     assert any("timeout" in s["content"] for s in run["steps"] if s["node"] == "error")
@@ -287,5 +292,6 @@ async def test_consecutive_errors_stop(monkeypatch, tmp_path):
     await run_chat_tools("loop", 1, run_id)
     run = crud.get_run(run_id)
     nodes = [s["node"] for s in run["steps"]]
-    assert nodes.count("tool:create_item") == 3
+    assert nodes.count("tool:create_item:request") == 3
+    assert nodes.count("tool:create_item:response") == 3
     assert "consecutive" in run["summary"].lower()


### PR DESCRIPTION
## Summary
- Record sanitized request and response steps for each tool call
- Mirror new request/response logging in intent parser path
- Stream tool steps over /stream and test real-time order

## Testing
- `pytest tests/test_api.py tests/test_chat_intents.py tests/test_executor_tools.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aacc64e4a08330b1261c7362abae91