### PR TITLE
Bind chat model to tools

### DIFF
--- a/orchestrator/core_loop.py
+++ b/orchestrator/core_loop.py
@@ -177,7 +177,8 @@ async def run_chat_tools(
     max_tool_calls: int = 10,
 ) -> dict:
     """Run a function-calling loop with the LLM."""
-    model = ChatOpenAI(model="gpt-4o-mini", temperature=0).bind_tools(TOOLS)
+    model = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+    model = model.bind_tools(TOOLS)
     messages: list[dict[str, str]] = [
         {"role": "system", "content": TOOL_SYSTEM_PROMPT},
         {"role": "user", "content": objective},


### PR DESCRIPTION
## Summary
- ensure `run_chat_tools` instantiates `ChatOpenAI` and binds tools explicitly

## Testing
- `pytest` *(fails: KeyboardInterrupt after ~4m, 3 tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4e1ed67c8330a39eb5c24100fa15