### PR TITLE
feat: add core loop diagnostics

### DIFF
--- a/tests/test_run_chat_tools.py
+++ b/tests/test_run_chat_tools.py
@@ -1,0 +1,93 @@
+import json
+import types
+
+import pytest
+
+from orchestrator import core_loop, crud
+
+crud.init_db()
+
+
+class _FakeChatWithTool:
+    def __init__(self, *args, **kwargs):
+        self._calls = 0
+
+    def bind_tools(self, tools):
+        return self
+
+    def invoke(self, messages):
+        self._calls += 1
+        if self._calls == 1:
+            return types.SimpleNamespace(
+                content="",
+                additional_kwargs={
+                    "tool_calls": [
+                        {
+                            "id": "1",
+                            "function": {
+                                "name": "create_item",
+                                "arguments": json.dumps(
+                                    {
+                                        "title": "t",
+                                        "type": "Epic",
+                                        "project_id": 1,
+                                        "secret": "sh",
+                                    }
+                                ),
+                            },
+                        }
+                    ]
+                },
+            )
+        return types.SimpleNamespace(content="done", additional_kwargs={})
+
+
+class _FakeChatNoTool:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def bind_tools(self, tools):
+        return self
+
+    def invoke(self, messages):
+        return types.SimpleNamespace(content="done", additional_kwargs={})
+
+
+@pytest.mark.asyncio
+async def test_run_chat_tools_logs_tool_execution(monkeypatch, caplog):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(core_loop, "ChatOpenAI", _FakeChatWithTool)
+
+    async def fake_run_tool(name, args):
+        return {"ok": True, "item_id": 1}
+
+    monkeypatch.setattr(core_loop, "_run_tool", fake_run_tool)
+
+    caplog.set_level("INFO")
+    result = await core_loop.run_chat_tools("do", 1, "run1")
+    assert result["html"]
+    assert "FULL-AGENT MODE: starting run_chat_tools(project_id=1)" in caplog.text
+    assert "OPENAI_API_KEY set: True" in caplog.text
+    assert "TOOLS loaded:" in caplog.text
+    assert "Model bound to" in caplog.text
+    assert "LLM tool_calls:" in caplog.text
+    assert "DISPATCH tool=create_item" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_run_chat_tools_logs_final_only(monkeypatch, caplog):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(core_loop, "ChatOpenAI", _FakeChatNoTool)
+    caplog.set_level("INFO")
+    result = await core_loop.run_chat_tools("do", 1, "run2")
+    assert result["html"]
+    assert "LLM tool_calls: None" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_run_chat_tools_logs_api_key_missing(monkeypatch, caplog):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(core_loop, "ChatOpenAI", _FakeChatNoTool)
+    caplog.set_level("INFO")
+    await core_loop.run_chat_tools("do", 1, "run3")
+    assert "OPENAI_API_KEY set: False" in caplog.text


### PR DESCRIPTION
## Summary
- add module-level logger and detailed diagnostics for run_chat_tools
- log LLM outputs, tool calls, and dispatch arguments
- cover run_chat_tools logging scenarios with unit tests

## Testing
- `pytest tests/test_run_chat_tools.py tests/test_chat_endpoint.py -q`
- `python - <<'PY'
import asyncio, json, types, logging, os
from unittest.mock import patch
from httpx import AsyncClient, ASGITransport
from api.main import app
from orchestrator import core_loop

logging.basicConfig(level=logging.INFO)
os.environ['OPENAI_API_KEY'] = 'test'

class FakeChat:
    def __init__(self, *a, **k):
        self.calls = 0
    def bind_tools(self, tools):
        return self
    def invoke(self, messages):
        self.calls += 1
        if self.calls == 1:
            return types.SimpleNamespace(
                content="",
                additional_kwargs={
                    "tool_calls": [
                        {
                            "id": "1",
                            "function": {
                                "name": "create_item",
                                "arguments": json.dumps({"title":"a","type":"Epic","project_id":1}),
                            },
                        }
                    ]
                },
            )
        return types.SimpleNamespace(content="final", additional_kwargs={})

async def run():
    transport = ASGITransport(app=app)
    with patch.object(core_loop, "ChatOpenAI", FakeChat):
        async def fake_run_tool(name, args):
            return {"ok": True, "item_id": 1}
        with patch.object(core_loop, "_run_tool", fake_run_tool):
            async with AsyncClient(transport=transport, base_url="http://test") as ac:
                resp = await ac.post("/chat", json={"objective":"demo","project_id":1})
                print("response:", resp.json())

asyncio.run(run())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68abff012e6083309e9386766d404eda