### PR TITLE
feat: refine tool system prompt

### DIFF
--- a/agents/planner.py
+++ b/agents/planner.py
@@ -20,12 +20,15 @@ def make_plan(objective: str) -> Plan:
 
 
 # Prompt used by the tool-enabled chat executor
-TOOL_SYSTEM_PROMPT = (
-    "You manage a product backlog via TOOLS. NEVER invent IDs or fields. "
-    "When an item is referenced by text, FIRST disambiguate using list_items/get_item. "
-    "If multiple candidates exist, ask ONE short clarification then stop. "
-    "Prefer concise outputs. After tool calls, summarize created/updated/deleted items with IDs. "
-    "Do NOT return a placeholder or 'stub'. If required info is missing (e.g., project_id), ask exactly one clarification and stop. "
-    "Keep total tool calls ≤ 10. "
-    "Avoid duplicates under the same parent (use list_items before create)."
-)
+TOOL_SYSTEM_PROMPT = """
+You are an assistant that MANAGES a product backlog using the provided TOOLS.
+Rules (must follow):
+- When a user asks to create/update/delete/move/list/get/summarize items, you MUST call a TOOL. Do NOT answer with plain text only.
+- NEVER invent IDs or fields.
+- When an item is referenced by text (title/type), FIRST disambiguate using list_items or get_item before update/delete/move.
+- If multiple candidates exist, ask exactly ONE short clarification question and then STOP.
+- Avoid duplicates: before create, check existence with list_items.
+- Keep ≤ 10 tool calls per objective. If you reach the limit, stop with a brief explanation.
+- Final answer should be concise. After tool calls, summarize what changed and list affected item IDs.
+- Do NOT return any placeholder like 'placeholder' or 'stub'. If critical info is missing (e.g., project_id), ask one question and stop.
+"""

--- a/tests/test_tool_prompt.py
+++ b/tests/test_tool_prompt.py
@@ -1,0 +1,6 @@
+from agents.planner import TOOL_SYSTEM_PROMPT
+
+
+def test_tool_system_prompt_contains_tool_call_requirement():
+    assert "MUST call a TOOL" in TOOL_SYSTEM_PROMPT
+    assert "Do NOT return any placeholder" in TOOL_SYSTEM_PROMPT


### PR DESCRIPTION
## Summary
- enforce tool usage for backlog changes
- warn against placeholder responses in system prompt
- add test to ensure prompt rules remain

## Testing
- `ruff check agents/planner.py tests/test_tool_prompt.py`
- `pytest -q` *(fails: WebSocketDisconnect: unknown run; NameError: writer is not defined)*
- `pytest tests/test_tool_prompt.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac53b8c6ac833084cd8c934fb3247b