### PR TITLE
Use LangChain message classes and tool binding

### DIFF
--- a/tests/test_run_chat_tools.py
+++ b/tests/test_run_chat_tools.py
@@ -12,7 +12,7 @@ class _FakeChatWithTool:
     def __init__(self, *args, **kwargs):
         self._calls = 0
 
-    def bind_tools(self, tools):
+    def bind_tools(self, tools, **kwargs):
         return self
 
     def invoke(self, messages):
@@ -46,7 +46,7 @@ class _FakeChatNoTool:
     def __init__(self, *args, **kwargs):
         pass
 
-    def bind_tools(self, tools):
+    def bind_tools(self, tools, **kwargs):
         return self
 
     def invoke(self, messages):


### PR DESCRIPTION
## Summary
- Use LangChain message classes for system, human and tool replies
- Explicitly bind tools with `tool_choice="auto"`
- Adjust tests to support new bind_tools signature

## Testing
- `pytest tests/test_run_chat_tools.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac55174a6883309bc35796aec08afc