### PR TITLE
Use LangChain messages with auto tool selection

### DIFF
--- a/orchestrator/core_loop.py
+++ b/orchestrator/core_loop.py
@@ -10,7 +10,10 @@ from uuid import uuid4
 from dotenv import load_dotenv
 from pydantic import BaseModel, Field, ConfigDict
 from langchain_openai import ChatOpenAI
-from langchain_core.messages import SystemMessage, HumanMessage, ToolMessage
+try:  # Prefer public schema import when available
+    from langchain.schema import SystemMessage, HumanMessage, ToolMessage
+except ImportError:  # pragma: no cover - fallback for older installs
+    from langchain_core.messages import SystemMessage, HumanMessage, ToolMessage
 from langgraph.graph import StateGraph, END
 
 from agents.planner import make_plan, TOOL_SYSTEM_PROMPT
@@ -200,10 +203,7 @@ async def run_chat_tools(
     await asyncio.sleep(0.05)
 
     model = ChatOpenAI(model="gpt-4o-mini", temperature=0)
-    try:
-        model = model.bind_tools(TOOLS, tool_choice="auto")
-    except TypeError:  # pragma: no cover - fallback for patched models
-        model = model.bind_tools(TOOLS)
+    model = model.bind_tools(TOOLS, tool_choice="auto")
     logger.info("Model bound to %d tools.", len(TOOLS))
     messages = [
         SystemMessage(content=TOOL_SYSTEM_PROMPT),


### PR DESCRIPTION
## Summary
- prefer importing LangChain message classes from public schema with fallback
- enforce auto tool choice when binding tools to ChatOpenAI

## Testing
- `pytest tests/test_run_chat_tools.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68acafd8a534833088935053b0f33816