### PR TITLE
Register run in stream before agent

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -117,7 +117,8 @@ async def chat(payload: dict) -> dict:
 
     run_id = str(uuid4())
     crud.create_run(run_id, objective, project_id)
-    stream.register(run_id, asyncio.get_event_loop())
+    # Register the run before launching the agent so clients can stream
+    stream.register(run_id)
     crud.record_run_step(run_id, "plan", json.dumps({"objective": objective}))
 
     await run_chat_tools(objective, project_id, run_id)

--- a/api/ws.py
+++ b/api/ws.py
@@ -27,8 +27,6 @@ async def stream_chat(ws: WebSocket):
         run_id = payload.get("run_id")
         objective = payload.get("objective")
         project_id = payload.get("project_id")
-        loop = asyncio.get_event_loop()
-
         if run_id:
             queue = stream.get(run_id)
             if queue is None:
@@ -55,7 +53,7 @@ async def stream_chat(ws: WebSocket):
                 return
             run_id = str(uuid4())
             crud.create_run(run_id, objective, project_id)
-            queue = stream.register(run_id, loop)
+            queue = stream.register(run_id)
             state = LoopState(
                 objective=objective,
                 project_id=project_id,

--- a/orchestrator/stream.py
+++ b/orchestrator/stream.py
@@ -5,8 +5,15 @@ from typing import Dict, Tuple
 _streams: Dict[str, Tuple[asyncio.Queue, asyncio.AbstractEventLoop]] = {}
 
 
-def register(run_id: str, loop: asyncio.AbstractEventLoop) -> asyncio.Queue:
-    """Create a queue for a run and remember its event loop."""
+def register(run_id: str, loop: asyncio.AbstractEventLoop | None = None) -> asyncio.Queue:
+    """Create a queue for a run and remember its event loop.
+
+    The loop parameter is optional and defaults to the current event loop.
+    This makes registration simpler for callers that are already running
+    inside the desired loop.
+    """
+    if loop is None:
+        loop = asyncio.get_event_loop()
     q: asyncio.Queue = asyncio.Queue()
     _streams[run_id] = (q, loop)
     return q

--- a/tests/test_chat_endpoint.py
+++ b/tests/test_chat_endpoint.py
@@ -89,7 +89,7 @@ async def test_chat_registers_stream(monkeypatch):
     registered: dict[str, str] = {}
     calls: list[str] = []
 
-    def fake_register(rid, loop):
+    def fake_register(rid, loop=None):
         calls.append("register")
         registered["run_id"] = rid
         return asyncio.Queue()


### PR DESCRIPTION
## Summary
- Register new chat runs with the stream layer before launching the agent
- Allow stream.register to default to current event loop
- Adapt websocket and tests to the new registration signature

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acb2ffc7988330bb99c91e3ffae1ab