### PR TITLE
Propagate run_id to tools via global hook

### DIFF
--- a/orchestrator/core_loop.py
+++ b/orchestrator/core_loop.py
@@ -177,7 +177,7 @@ async def run_chat_tools(
     import os
     from langchain.prompts import ChatPromptTemplate, MessagesPlaceholder
     from langchain.agents import AgentExecutor, create_tool_calling_agent
-    from agents.tools import TOOLS
+    from agents.tools import TOOLS, set_current_run
     from agents.planner import TOOL_SYSTEM_PROMPT
 
     logger.info("FULL-AGENT MODE: starting run_chat_tools(project_id=%s)", project_id)
@@ -202,6 +202,7 @@ async def run_chat_tools(
 
     inputs = {"input": objective}
     config = {"configurable": {"run_id": run_id, "project_id": project_id}}
+    set_current_run(run_id)
 
     try:
         result = await executor.ainvoke(inputs, config=config)

--- a/tests/test_tools_run_id.py
+++ b/tests/test_tools_run_id.py
@@ -1,0 +1,22 @@
+import pytest
+from pydantic import BaseModel
+import agents.tools as tool_mod
+
+
+class Dummy(BaseModel):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_tool_uses_global_run_id(monkeypatch):
+    captured = {}
+
+    async def fake_exec(name, run_id, args):
+        captured["run_id"] = run_id
+        return "ok"
+
+    monkeypatch.setattr(tool_mod, "_exec", fake_exec)
+    tool_mod.set_current_run("abc")
+    tool = tool_mod._mk_tool("t", "desc", Dummy)
+    await tool.coroutine()
+    assert captured["run_id"] == "abc"


### PR DESCRIPTION
## Summary
- add global `set_current_run` hook in tool wrappers
- ensure `run_chat_tools` sets current run before tool execution
- test run_id propagation including global fallback

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b07ce777f88330a91ca22e8f0f7c08