### PR TITLE
fix: invoke ChatOpenAI synchronously

### DIFF
--- a/orchestrator/core_loop.py
+++ b/orchestrator/core_loop.py
@@ -48,7 +48,9 @@ async def run_chat_tools(objective: str, project_id: int | None, run_id: str, ma
     consecutive_errors = 0
 
     for _ in range(max_tool_calls):
-        rsp: AIMessage = await llm.ainvoke(messages)
+        # ChatOpenAI fournit uniquement une API synchrone. Exécuter l'appel dans un
+        # thread permet de ne pas bloquer la boucle d'événements.
+        rsp: AIMessage = await asyncio.to_thread(llm.invoke, messages)
         logger.info("AIMessage content: %r", getattr(rsp, "content", None))
         logger.info("AIMessage tool_calls: %s", getattr(rsp, "tool_calls", None))
 

--- a/tests/test_executor_tools.py
+++ b/tests/test_executor_tools.py
@@ -23,7 +23,7 @@ class FakeLLM:
     def bind_tools(self, tools):
         return self
 
-    async def ainvoke(self, messages):
+    def invoke(self, messages):
         res = self.responses[self.calls]
         self.calls += 1
         return res

--- a/tests/test_run_chat_tools.py
+++ b/tests/test_run_chat_tools.py
@@ -20,7 +20,7 @@ class FakeLLM:
     def bind_tools(self, tools):
         return self
 
-    async def ainvoke(self, messages):
+    def invoke(self, messages):
         res = self.responses[self.calls]
         self.calls += 1
         return res


### PR DESCRIPTION
## Summary
- run ChatOpenAI calls in a thread using `invoke` to avoid missing async interface
- adjust tests to match synchronous LLM interface and stream tool steps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0aa29600483309caa3f4e53c17fb3