### PR TITLE
fix: add comprehensive CORS handling

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -79,13 +79,13 @@ origins = [
     "http://localhost:9080",
     "http://192.168.1.93:3000",
     "http://192.168.1.93:8000",
-    "*"  # permissive dev CORS for cross-network access
 ]
 
-# Autorise l’origine du front (dev localhost:3000/5173)
+# Allow configured origins and fall back to accepting any HTTP(S) origin for dev
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,
+    allow_origin_regex=r"https?://.*",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,26 @@
+from fastapi.testclient import TestClient
+from api.main import app
+
+
+def test_cors_headers_for_projects_endpoint():
+    client = TestClient(app)
+    response = client.get(
+        "/projects",
+        headers={"Origin": "http://localhost:3000"},
+    )
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "http://localhost:3000"
+    assert response.headers["access-control-allow-credentials"] == "true"
+
+
+def test_cors_preflight_options_handled():
+    client = TestClient(app)
+    response = client.options(
+        "/projects",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "http://localhost:3000"


### PR DESCRIPTION
## Summary
- expand FastAPI CORS config to allow any HTTP(S) origin and remove wildcard entry
- cover CORS behaviour with unit tests for normal and preflight requests

## Testing
- `pytest tests/test_cors.py -q`
- `pytest -q` *(fails: test suite has 9 failing tests unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b260db348330b8b58534ef7ab065