### PR TITLE
Add document model and CRUD operations

### DIFF
--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -13,6 +13,27 @@ class ProjectCreate(BaseModel):
     description: str | None = None
 
 
+class Document(BaseModel):
+    """File uploaded to a project."""
+
+    id: int
+    project_id: int
+    filename: str
+    content: str | None = None
+    embedding: list[float] | None = None
+
+
+class DocumentCreate(BaseModel):
+    project_id: int
+    filename: str
+    content: str | None = None
+    embedding: list[float] | None = None
+
+
+# For symmetry with other models
+DocumentOut = Document
+
+
 class RunStep(BaseModel):
     """Timeline entry for a run."""
 

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,0 +1,38 @@
+import pytest
+from orchestrator import crud
+from orchestrator.models import ProjectCreate
+
+
+def setup_db(tmp_path, monkeypatch):
+    db = tmp_path / "db.sqlite"
+    monkeypatch.setattr(crud, "DATABASE_URL", str(db))
+    crud.init_db()
+    project = crud.create_project(ProjectCreate(name="Test", description=None))
+    return project
+
+
+def test_document_crud(tmp_path, monkeypatch):
+    project = setup_db(tmp_path, monkeypatch)
+    doc = crud.create_document(project.id, "file.txt", "content", [0.1, 0.2])
+    fetched = crud.get_document(doc.id)
+    assert fetched == doc
+    docs = crud.get_documents(project.id)
+    assert len(docs) == 1 and docs[0] == doc
+
+
+def test_get_documents_empty(tmp_path, monkeypatch):
+    project = setup_db(tmp_path, monkeypatch)
+    docs = crud.get_documents(project.id)
+    assert docs == []
+
+
+def test_get_document_not_found(tmp_path, monkeypatch):
+    project = setup_db(tmp_path, monkeypatch)
+    assert crud.get_document(999) is None
+
+
+def test_create_document_invalid_filename(tmp_path, monkeypatch):
+    project = setup_db(tmp_path, monkeypatch)
+    with pytest.raises(ValueError):
+        crud.create_document(project.id, "", None, None)
+


### PR DESCRIPTION
## Summary
- add `Document` pydantic model with creation schema
- extend SQLite schema and CRUD helpers for project documents
- cover document storage with unit tests

## Testing
- `pytest tests/test_documents.py -q`
- `pytest -q` *(fails: No valid tools available and assertion mismatches in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f3c845fc8330b521c26fd712d900