### PR TITLE
feat: add document upload endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ typer = "^0.16.0"
 pydantic = "^2.11.7"
 langchain = ">=0.2.0"
 httpx = "^0.28.1"
+python-multipart = "^0.0.9"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.1"

--- a/tests/test_document_api.py
+++ b/tests/test_document_api.py
@@ -1,0 +1,56 @@
+import os
+import pytest
+from httpx import AsyncClient
+from httpx_ws.transport import ASGIWebSocketTransport
+from api.main import app
+from orchestrator import crud
+from orchestrator.models import ProjectCreate
+
+transport = ASGIWebSocketTransport(app=app)
+
+
+@pytest.mark.asyncio
+async def test_upload_list_and_download(tmp_path, monkeypatch):
+    db = tmp_path / "db.sqlite"
+    monkeypatch.setattr(crud, "DATABASE_URL", str(db))
+    crud.init_db()
+    project = crud.create_project(ProjectCreate(name="P", description=None))
+
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        files = {"file": ("note.txt", b"hello", "text/plain")}
+        r = await ac.post(f"/projects/{project.id}/documents", files=files)
+        assert r.status_code == 201
+        doc = r.json()
+        assert doc["filename"] == "note.txt"
+
+        rlist = await ac.get(f"/projects/{project.id}/documents")
+        assert rlist.status_code == 200
+        assert len(rlist.json()) == 1
+        assert rlist.json()[0]["id"] == doc["id"]
+
+        rcontent = await ac.get(f"/documents/{doc['id']}/content")
+        assert rcontent.status_code == 200
+        assert rcontent.text == "hello"
+
+
+@pytest.mark.asyncio
+async def test_upload_document_project_not_found(tmp_path, monkeypatch):
+    db = tmp_path / "db.sqlite"
+    monkeypatch.setattr(crud, "DATABASE_URL", str(db))
+    crud.init_db()
+
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        files = {"file": ("note.txt", b"hello", "text/plain")}
+        r = await ac.post("/projects/999/documents", files=files)
+        assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_document_content_not_found(tmp_path, monkeypatch):
+    db = tmp_path / "db.sqlite"
+    monkeypatch.setattr(crud, "DATABASE_URL", str(db))
+    crud.init_db()
+
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        r = await ac.get("/documents/123/content")
+        assert r.status_code == 404


### PR DESCRIPTION
## Summary
- add FastAPI endpoints to upload, list, and fetch document content for projects
- add python-multipart dependency for file uploads
- cover document API with tests

## Testing
- `python -m pytest tests/test_document_api.py tests/test_documents.py -q`
- `python -m pytest -q` *(fails: test_ws_stream_tool_steps, test_planner_llm_model, test_writer_llm_model, test_core_loop_uses_gpt5, test_run_chat_tools_injects_ids, test_run_chat_tools_handles_unknown_tool, test_run_chat_tools_returns_summary, test_run_chat_tools_stops_after_errors, test_tool_system_prompt_contains_tool_call_requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f672d11483309b28c93b1fd80003