### PR TITLE
test: add document upload tests and frontend coverage

### DIFF
--- a/frontend/src/components/__tests__/ProjectPanel.test.tsx
+++ b/frontend/src/components/__tests__/ProjectPanel.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { ProjectPanel } from '../project/ProjectPanel';
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() }
+}));
+
+vi.mock('@/context/ProjectContext', () => ({
+  useProjects: () => ({
+    projects: [{ id: 1, name: 'P', description: '' }],
+    currentProject: { id: 1, name: 'P', description: '' },
+    setCurrentProject: vi.fn(),
+    refreshProjects: vi.fn(),
+  })
+}));
+
+const listDocuments = vi.fn();
+const uploadDocument = vi.fn();
+
+vi.mock('@/lib/documents', () => ({
+  listDocuments: (...args: any[]) => listDocuments(...args),
+  uploadDocument: (...args: any[]) => uploadDocument(...args),
+}));
+
+describe('ProjectPanel document upload', () => {
+  it('uploads file and refreshes list', async () => {
+    listDocuments.mockResolvedValueOnce([]);
+    const uploaded = { id: 1, project_id: 1, filename: 'test.txt' };
+    listDocuments.mockResolvedValue([uploaded]);
+    uploadDocument.mockResolvedValue(uploaded);
+
+    render(<ProjectPanel />);
+
+    const file = new File(['hello'], 'test.txt', { type: 'text/plain' });
+    const input = screen.getByLabelText(/upload file/i);
+    fireEvent.change(input, { target: { files: [file] } });
+
+    fireEvent.click(screen.getByRole('button', { name: /upload/i }));
+
+    await waitFor(() => expect(uploadDocument).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByText('test.txt')).toBeInTheDocument());
+  });
+});

--- a/frontend/src/components/project/ProjectPanel.tsx
+++ b/frontend/src/components/project/ProjectPanel.tsx
@@ -212,6 +212,7 @@ export function ProjectPanel() {
                   onChange={handleFileChange}
                   ref={fileInputRef}
                   className="flex-1"
+                  aria-label="Upload file"
                 />
                 <Button
                   onClick={handleUpload}

--- a/tests/test_embedding_service.py
+++ b/tests/test_embedding_service.py
@@ -1,6 +1,7 @@
 import pytest
 import json
 import asyncio
+import os
 from unittest.mock import Mock, AsyncMock, patch
 from orchestrator.embedding_service import (
     EmbeddingService,

--- a/tests/test_vector_search.py
+++ b/tests/test_vector_search.py
@@ -1,0 +1,26 @@
+import pytest
+from orchestrator.embedding_service import EmbeddingService
+
+
+@pytest.mark.asyncio
+async def test_vector_search_top_result():
+    service = EmbeddingService(api_key="test-key")
+    query = [1.0, 0.0]
+    chunks = [
+        {"text": "match", "embedding": [0.9, 0.1]},
+        {"text": "other", "embedding": [0.0, 1.0]},
+    ]
+    result = await service.find_similar_chunks(query, chunks, top_k=1)
+    assert len(result) == 1
+    assert result[0]["text"] == "match"
+
+
+@pytest.mark.asyncio
+async def test_vector_search_no_results():
+    service = EmbeddingService(api_key="test-key")
+    query = [1.0, 0.0]
+    chunks = [
+        {"text": "unrelated", "embedding": [0.0, 1.0]},
+    ]
+    result = await service.find_similar_chunks(query, chunks, top_k=5, similarity_threshold=0.9)
+    assert result == []


### PR DESCRIPTION
## Summary
- add API tests for document upload, listing, and PDF content extraction
- cover vector search similarity logic
- add ProjectPanel upload workflow test and accessible file input label

## Testing
- `pytest tests/test_api.py::test_document_upload_and_listing -q`
- `pytest tests/test_api.py::test_pdf_content_extraction -q`
- `pytest tests/test_vector_search.py -q`
- `pytest tests/test_embedding_service.py::TestSimilaritySearch::test_find_similar_chunks_success -q`
- `cd frontend && pnpm test src/components/__tests__/ProjectPanel.test.tsx`
- `pytest -q` *(fails: numerous tests and process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68b4445468188330b3422ac9fef33a9f