### PR TITLE
fix undefined logger in document upload

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -65,6 +65,7 @@ async def _no_aexit(self, exc_type=None, exc_value=None, traceback=None):
 httpx.AsyncClient.__aexit__ = _no_aexit
 
 setup_logging()
+logger = logging.getLogger(__name__)
 
 app = FastAPI()
 crud.init_db()


### PR DESCRIPTION
## Summary
- define module-level logger in API
- add regression test ensuring upload continues when embedding generation fails

## Testing
- `pytest tests/test_document_api.py::test_upload_document_embedding_error -q`
- `pytest tests/test_document_api.py::test_upload_list_and_download -q`


------
https://chatgpt.com/codex/tasks/task_e_68b48977ef90833083a0c18253ef6f21