### PR TITLE
feat: add document deletion with deindexing

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -255,7 +255,7 @@ async def get_document_content(doc_id: int):
     doc = crud.get_document(doc_id)
     if not doc:
         raise HTTPException(status_code=404, detail="document not found")
-    return Response(doc.content or "", media_type="text/plain")
+    return Response(doc.get("content") or "", media_type="text/plain")
 
 
 @app.get("/documents/{doc_id}/chunks")
@@ -266,9 +266,28 @@ async def get_document_chunks(doc_id: int):
     doc = crud.get_document(doc_id)
     if not doc:
         raise HTTPException(status_code=404, detail="document not found")
-    
+
     chunks = crud.get_document_chunks(doc_id)
     return chunks
+
+
+@app.delete("/documents/{doc_id}")
+def delete_document_api(doc_id: int):
+    doc = crud.get_document(doc_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    crud.delete_document_chunks(doc_id)
+
+    fp = doc.get("filepath")
+    if fp:
+        try:
+            os.remove(fp)
+        except FileNotFoundError:
+            pass
+
+    ok = crud.delete_document(doc_id)
+    return {"ok": bool(ok)}
 
 
 @app.post("/projects/{project_id}/search")

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -21,6 +21,7 @@ class Document(BaseModel):
     filename: str
     content: str | None = None
     embedding: list[float] | None = None
+    filepath: str | None = None
 
 
 class DocumentCreate(BaseModel):
@@ -28,6 +29,7 @@ class DocumentCreate(BaseModel):
     filename: str
     content: str | None = None
     embedding: list[float] | None = None
+    filepath: str | None = None
 
 
 # For symmetry with other models

--- a/tests/test_embedding_api.py
+++ b/tests/test_embedding_api.py
@@ -225,7 +225,7 @@ class TestSemanticSearchAPI:
                         "chunk_index": 0,
                         "embedding": [0.9, 0.1, 0.0],
                         "similarity_score": 0.99,
-                        "document_id": 1,
+                        "doc_id": 1,
                         "filename": "doc1.txt"
                     },
                     {
@@ -233,7 +233,7 @@ class TestSemanticSearchAPI:
                         "chunk_index": 1,
                         "embedding": [0.8, 0.2, 0.0],
                         "similarity_score": 0.89,
-                        "document_id": 1,
+                        "doc_id": 1,
                         "filename": "doc1.txt"
                     }
                 ]
@@ -415,7 +415,7 @@ class TestEmbeddingIntegration:
                             "chunk_index": 0,
                             "embedding": [0.9, 0.1, 0.0, 0.0, 0.0],
                             "similarity_score": 0.95,
-                            "document_id": document["id"],
+                            "doc_id": document["id"],
                             "filename": "ai_doc.txt"
                         }
                     ]


### PR DESCRIPTION
## Summary
- add filepath support and doc chunk table keyed by `doc_id`
- implement CRUD helpers and API endpoint for deleting documents and chunks
- ensure documents table has filepath column and document files are removed

## Testing
- `pytest tests/test_documents.py -q`
- `pytest tests/test_embedding_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4909c6ae08330babe22f52253236d