### PR TITLE
feat(frontend): allow deleting project documents

### DIFF
--- a/frontend/src/components/__tests__/DocumentList.test.tsx
+++ b/frontend/src/components/__tests__/DocumentList.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { DocumentList } from '../project/DocumentList';
+import { toast } from 'sonner';
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() }
+}));
+
+const deleteDocument = vi.fn();
+vi.mock('@/lib/documents', () => ({
+  deleteDocument: (...args: any[]) => deleteDocument(...args)
+}));
+
+const docs = [{ id: 1, project_id: 1, filename: 'doc.txt' }];
+
+describe('DocumentList', () => {
+  beforeEach(() => {
+    deleteDocument.mockReset();
+  });
+
+  it('deletes document after confirmation', async () => {
+    const refetch = vi.fn();
+    let resolve: () => void;
+    deleteDocument.mockImplementation(() => new Promise(r => { resolve = r; }));
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(<DocumentList documents={docs} refetch={refetch} />);
+    const button = screen.getByRole('button', { name: /delete doc.txt/i });
+    fireEvent.click(button);
+    expect(button).toBeDisabled();
+    resolve!();
+    await waitFor(() => expect(refetch).toHaveBeenCalled());
+    await waitFor(() => expect(button).not.toBeDisabled());
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it('does not delete when confirmation is cancelled', () => {
+    const refetch = vi.fn();
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    render(<DocumentList documents={docs} refetch={refetch} />);
+    fireEvent.click(screen.getByRole('button', { name: /delete doc.txt/i }));
+    expect(deleteDocument).not.toHaveBeenCalled();
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  it('shows error toast on failure', async () => {
+    const refetch = vi.fn();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    deleteDocument.mockRejectedValue(new Error('fail'));
+    render(<DocumentList documents={docs} refetch={refetch} />);
+    fireEvent.click(screen.getByRole('button', { name: /delete doc.txt/i }));
+    await waitFor(() => expect(deleteDocument).toHaveBeenCalled());
+    await waitFor(() => expect(refetch).not.toHaveBeenCalled());
+    expect(toast.error).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/project/DocumentList.tsx
+++ b/frontend/src/components/project/DocumentList.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState } from 'react';
+import { Trash } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
+import { getApiBaseUrl } from '@/lib/api';
+import { deleteDocument } from '@/lib/documents';
+import type { Document } from '@/models/document';
+
+interface DocumentListProps {
+  documents: Document[];
+  refetch: () => Promise<void>;
+}
+
+export function DocumentList({ documents, refetch }: DocumentListProps) {
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+
+  const handleDelete = async (id: number) => {
+    if (!confirm('Supprimer ce document ?')) return;
+    try {
+      setDeletingId(id);
+      await deleteDocument(id);
+      await refetch();
+      toast.success('Document deleted');
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to delete document');
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  if (documents.length === 0) {
+    return <p className="text-sm text-muted-foreground">No documents uploaded.</p>;
+  }
+
+  return (
+    <ul className="list-disc list-inside space-y-1">
+      {documents.map((doc) => (
+        <li key={doc.id} className="flex items-center gap-2">
+          <a
+            href={`${getApiBaseUrl()}/documents/${doc.id}/content`}
+            className="text-blue-500 hover:underline"
+            download
+          >
+            {doc.filename}
+          </a>
+          <Button
+            variant="destructive"
+            size="icon"
+            aria-label={`Delete ${doc.filename}`}
+            disabled={deletingId === doc.id}
+            onClick={() => handleDelete(doc.id)}
+          >
+            <Trash className="h-4 w-4" />
+          </Button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/components/project/ProjectPanel.tsx
+++ b/frontend/src/components/project/ProjectPanel.tsx
@@ -11,9 +11,10 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { useProjects } from '@/context/ProjectContext';
 import { toast } from 'sonner';
-import { http, getApiBaseUrl } from '@/lib/api';
+import { http } from '@/lib/api';
 import type { Document } from '@/models/document';
 import { listDocuments, uploadDocument } from '@/lib/documents';
+import { DocumentList } from './DocumentList';
 
 export function ProjectPanel() {
   const { projects, currentProject, setCurrentProject, refreshProjects } = useProjects();
@@ -224,25 +225,7 @@ export function ProjectPanel() {
 
               <div>
                 <h4 className="font-medium mb-2">Documents</h4>
-                {documents.length > 0 ? (
-                  <ul className="list-disc list-inside space-y-1">
-                    {documents.map((doc) => (
-                      <li key={doc.id}>
-                        <a
-                          href={`${getApiBaseUrl()}/documents/${doc.id}/content`}
-                          className="text-blue-500 hover:underline"
-                          download
-                        >
-                          {doc.filename}
-                        </a>
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <p className="text-sm text-muted-foreground">
-                    No documents uploaded.
-                  </p>
-                )}
+                <DocumentList documents={documents} refetch={loadDocuments} />
               </div>
             </div>
           </div>

--- a/frontend/src/lib/documents.test.ts
+++ b/frontend/src/lib/documents.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { listDocuments, uploadDocument } from './documents';
+import { listDocuments, uploadDocument, deleteDocument } from './documents';
 
 // Mock fetch globally
 const globalAny: any = global;
@@ -41,6 +41,26 @@ describe('documents api', () => {
       globalAny.fetch.mockResolvedValue({ ok: false });
       const file = new File(['hello'], 'test.txt');
       await expect(uploadDocument(1, file)).rejects.toThrow('Failed to upload document');
+    });
+  });
+
+  describe('deleteDocument', () => {
+    it('sends delete request and returns response', async () => {
+      const doc = { ok: true, json: () => Promise.resolve({}) };
+      globalAny.fetch.mockResolvedValue(doc);
+      await deleteDocument(1);
+      const [url, options] = globalAny.fetch.mock.calls[0];
+      expect(url).toBe('/api/documents/1');
+      expect(options.method).toBe('DELETE');
+    });
+
+    it('throws on delete failure', async () => {
+      globalAny.fetch.mockResolvedValue({ ok: false });
+      await expect(deleteDocument(1)).rejects.toThrow('Failed to delete document');
+    });
+
+    it('validates document id', async () => {
+      await expect(deleteDocument(0)).rejects.toThrow('Invalid document ID');
     });
   });
 });

--- a/frontend/src/lib/documents.ts
+++ b/frontend/src/lib/documents.ts
@@ -21,3 +21,15 @@ export async function uploadDocument(projectId: number, file: File): Promise<Doc
   }
   return response.json();
 }
+
+export async function deleteDocument(docId: number) {
+  if (!Number.isInteger(docId) || docId <= 0) {
+    throw new Error('Invalid document ID');
+  }
+  const res = await http(`/documents/${docId}`, {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!res.ok) throw new Error('Failed to delete document');
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add API helper to delete documents
- show document list with delete controls
- cover document deletion with tests

## Testing
- `pnpm test src/lib/documents.test.ts src/components/__tests__/DocumentList.test.tsx --run`
- `pnpm test` *(fails: multiple unrelated tests, e.g., BacklogPane requires context)*

------
https://chatgpt.com/codex/tasks/task_e_68b493b764388330b1e8013b981ee1a1