### PR TITLE
feat: add backlog diagram hybrid layout

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,11 @@
     "swr": "^2.3.4",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
-    "zustand": "^5.0.8"
+    "zustand": "^5.0.8",
+    "dagre": "^0.8",
+    "d3-force": "^3",
+    "d3-zoom": "^3",
+    "d3-selection": "^3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -26,6 +26,18 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      d3-force:
+        specifier: ^3
+        version: 3.0.0
+      d3-selection:
+        specifier: ^3
+        version: 3.0.0
+      d3-zoom:
+        specifier: ^3
+        version: 3.0.0
+      dagre:
+        specifier: ^0.8
+        version: 0.8.5
       lucide-react:
         specifier: ^0.525.0
         version: 0.525.0(react@19.1.0)
@@ -2259,6 +2271,55 @@ packages:
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  dagre@0.8.5:
+    resolution: {integrity: sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -2647,6 +2708,9 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  graphlib@2.1.8:
+    resolution: {integrity: sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -2970,6 +3034,9 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -6282,6 +6349,55 @@ snapshots:
 
   csstype@3.1.3: {}
 
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-quadtree@3.0.1: {}
+
+  d3-selection@3.0.0: {}
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  dagre@0.8.5:
+    dependencies:
+      graphlib: 2.1.8
+      lodash: 4.17.21
+
   damerau-levenshtein@1.0.8: {}
 
   data-urls@5.0.0:
@@ -6830,6 +6946,10 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  graphlib@2.1.8:
+    dependencies:
+      lodash: 4.17.21
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -7152,6 +7272,8 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.merge@4.6.2: {}
+
+  lodash@4.17.21: {}
 
   loose-envify@1.4.0:
     dependencies:

--- a/frontend/src/components/BacklogViewTabs.tsx
+++ b/frontend/src/components/BacklogViewTabs.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { ItemTree } from '@/components/ItemTree';
 import { BacklogTable } from '@/components/BacklogTable';
-import { BacklogDiagram } from '@/components/BacklogDiagram';
+import { DiagramView } from '@/components/backlog/DiagramView';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { BacklogItem } from '@/models/backlogItem';
 
@@ -28,7 +28,7 @@ export function BacklogViewTabs({ projectId, onEdit }: BacklogViewTabsProps) {
       </TabsContent>
 
       <TabsContent value="diagram">
-        <BacklogDiagram projectId={projectId} onEdit={onEdit} />
+        <DiagramView projectId={projectId} />
       </TabsContent>
     </Tabs>
   );

--- a/frontend/src/components/backlog/DiagramView.tsx
+++ b/frontend/src/components/backlog/DiagramView.tsx
@@ -1,0 +1,261 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import dagre from 'dagre';
+import { forceSimulation, forceCollide, forceX, forceY, forceLink } from 'd3-force';
+import { zoom } from 'd3-zoom';
+import { select } from 'd3-selection';
+import { BacklogItem } from '@/models/backlogItem';
+import { useItems } from '@/lib/hooks';
+import { getLayout, saveLayout, LayoutNode } from '@/lib/layout';
+import { useAutoFit, BBox } from './useAutoFit';
+import { Button } from '@/components/ui/button';
+
+interface DiagramViewProps {
+  projectId: number | null;
+}
+
+interface NodeDatum {
+  id: number;
+  title: string;
+  type: BacklogItem['type'];
+  parent_id: number | null;
+  rank: number;
+  width: number;
+  height: number;
+  x: number;
+  y: number;
+  fx?: number;
+  fy?: number;
+  pinned?: boolean;
+}
+
+const typeColor: Record<string, string> = {
+  Epic: '#8b5cf6',
+  Capability: '#a78bfa',
+  Feature: '#3b82f6',
+  US: '#10b981',
+  UC: '#f59e0b',
+};
+
+const rankByType: Record<BacklogItem['type'], number> = {
+  Epic: 0,
+  Capability: 1,
+  Feature: 2,
+  US: 3,
+  UC: 4,
+};
+
+export function DiagramView({ projectId }: DiagramViewProps) {
+  const { data: items } = useItems(projectId);
+  const [nodes, setNodes] = useState<NodeDatum[]>([]);
+  const [edges, setEdges] = useState<{ source: number; target: number }[]>([]);
+  const [focused, setFocused] = useState<number | null>(null);
+  const svgRef = useRef<SVGSVGElement>(null);
+  const zoomRef = useRef(returnZoom());
+  const autoFit = useAutoFit(svgRef);
+  const saveTimer = useRef<NodeJS.Timeout | null>(null);
+
+  function returnZoom() {
+    return zoom<SVGSVGElement, unknown>().scaleExtent([0.2, 2.5]);
+  }
+
+  // Measure text width
+  const measure = useMemo(() => {
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    return (text: string) => {
+      if (!ctx) return 120;
+      ctx.font = '12px sans-serif';
+      return Math.max(120, ctx.measureText(text).width + 24);
+    };
+  }, []);
+
+  // Build graph
+  useEffect(() => {
+    if (!items || !projectId) return;
+    const n: NodeDatum[] = items.map(item => ({
+      id: item.id,
+      title: item.title,
+      type: item.type,
+      parent_id: item.parent_id,
+      rank: rankByType[item.type],
+      width: measure(item.title),
+      height: 40,
+      x: 0,
+      y: 0,
+    }));
+    const e = n
+      .filter(nd => nd.parent_id !== null)
+      .map(nd => ({ source: nd.parent_id as number, target: nd.id }));
+    setNodes(n);
+    setEdges(e);
+  }, [items, measure, projectId]);
+
+  // Merge saved layout
+  useEffect(() => {
+    if (!projectId || nodes.length === 0) return;
+    getLayout(projectId).then(saved => {
+      setNodes(nds =>
+        nds.map(nd => {
+          const found = saved.find(s => s.item_id === nd.id);
+          return found ? { ...nd, x: found.x, y: found.y, pinned: found.pinned, fx: found.pinned ? found.x : undefined, fy: found.pinned ? found.y : undefined } : nd;
+        })
+      );
+    });
+  }, [projectId, nodes.length]);
+
+  // Layout with dagre + force
+  useEffect(() => {
+    if (nodes.length === 0 || edges.length === 0) return;
+    const g = new dagre.graphlib.Graph();
+    g.setGraph({ rankdir: 'LR', nodesep: 40, ranksep: 80 });
+    nodes.forEach(nd => g.setNode(nd.id, { width: nd.width, height: nd.height, rank: nd.rank }));
+    edges.forEach(e => g.setEdge(e.source, e.target));
+    dagre.layout(g);
+    const initial = nodes.map(nd => {
+      const pos = g.node(nd.id);
+      return { ...nd, x: nd.pinned ? nd.x : pos.x, y: nd.pinned ? nd.y : pos.y };
+    });
+    const sim = forceSimulation(initial)
+      .force('collide', forceCollide<NodeDatum>(d => Math.max(d.width, d.height) / 2 + 8))
+      .force('x', forceX<NodeDatum>(d => d.rank * 280).strength(1))
+      .force('y', forceY<NodeDatum>(0).strength(0.05))
+      .force('link', forceLink<NodeDatum, { source: number; target: number }>(edges).id(d => (d as any).id).distance(120))
+      .alpha(0.5);
+    for (let i = 0; i < 300 && sim.alpha() > 0.02; i++) {
+      sim.tick();
+    }
+    sim.stop();
+    setNodes(sim.nodes() as NodeDatum[]);
+  }, [nodes.length, edges]);
+
+  // Setup zoom
+  useEffect(() => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    select(svg).call(zoomRef.current.on('zoom', (e) => {
+      select(svg).select('g').attr('transform', e.transform);
+    }));
+    // initial fit
+    const bbox = computeBBox(nodes);
+    if (bbox) autoFit(bbox);
+  }, [nodes, autoFit]);
+
+  // Dragging
+  const dragNode = useRef<NodeDatum | null>(null);
+  function onPointerDown(e: React.PointerEvent, node: NodeDatum) {
+    dragNode.current = node;
+    node.fx = node.x;
+    node.fy = node.y;
+    (e.target as Element).setPointerCapture(e.pointerId);
+  }
+  function onPointerMove(e: React.PointerEvent) {
+    if (!dragNode.current) return;
+    const pt = pointer(e, svgRef.current);
+    dragNode.current.x = pt[0];
+    dragNode.current.y = pt[1];
+    dragNode.current.fx = pt[0];
+    dragNode.current.fy = pt[1];
+    setNodes([...nodes]);
+  }
+  function onPointerUp(e: React.PointerEvent) {
+    if (!dragNode.current) return;
+    dragNode.current.pinned = true;
+    dragNode.current.fx = dragNode.current.x;
+    dragNode.current.fy = dragNode.current.y;
+    dragNode.current = null;
+    if (saveTimer.current) clearTimeout(saveTimer.current);
+    saveTimer.current = setTimeout(() => {
+      if (!projectId) return;
+      saveLayout(projectId, nodes.map(n => ({ item_id: n.id, x: n.x, y: n.y, pinned: n.pinned })));
+    }, 500);
+  }
+
+  function pointer(event: React.PointerEvent, svg: SVGSVGElement | null) {
+    const pt = svg?.createSVGPoint();
+    if (!pt) return [0, 0];
+    pt.x = event.clientX;
+    pt.y = event.clientY;
+    const gpt = pt.matrixTransform(svg.getScreenCTM()?.inverse());
+    return [gpt.x, gpt.y];
+  }
+
+  // Focus subtree
+  const visible = useMemo(() => {
+    if (!focused) return nodes.map(n => n.id);
+    const ids = new Set<number>();
+    const queue = [focused];
+    while (queue.length) {
+      const id = queue.shift()!;
+      ids.add(id);
+      edges.filter(e => e.source === id).forEach(e => queue.push(e.target));
+    }
+    return Array.from(ids);
+  }, [focused, nodes, edges]);
+
+  useEffect(() => {
+    // auto fit focused subtree
+    const visNodes = nodes.filter(n => visible.includes(n.id));
+    const bbox = computeBBox(visNodes);
+    if (bbox) autoFit(bbox);
+  }, [focused]);
+
+  function computeBBox(nds: NodeDatum[]): BBox | null {
+    if (nds.length === 0) return null;
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    nds.forEach(n => {
+      minX = Math.min(minX, n.x - n.width / 2);
+      maxX = Math.max(maxX, n.x + n.width / 2);
+      minY = Math.min(minY, n.y - n.height / 2);
+      maxY = Math.max(maxY, n.y + n.height / 2);
+    });
+    return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+  }
+
+  function handleReset() {
+    setFocused(null);
+    const bbox = computeBBox(nodes);
+    if (bbox) autoFit(bbox);
+  }
+
+  if (!projectId) return null;
+
+  if (nodes.length >= 300) {
+    return <div className="p-4 text-sm">Diagram too large to render.</div>;
+  }
+
+  return (
+    <div className="relative h-[600px] border rounded">
+      <svg ref={svgRef} className="w-full h-full" onPointerMove={onPointerMove} onPointerUp={onPointerUp}>
+        <g>
+          {edges.map((e, i) => {
+            const s = nodes.find(n => n.id === e.source)!;
+            const t = nodes.find(n => n.id === e.target)!;
+            const path = `M${s.x + s.width / 2},${s.y} Q${(s.x + t.x) / 2},${s.y} ${t.x - t.width / 2},${t.y}`;
+            return <path key={i} d={path} fill="none" stroke="#ccc" />;
+          })}
+          {nodes.map(n => (
+            <g key={n.id}
+               opacity={visible.includes(n.id) ? 1 : 0.2}
+               transform={`translate(${n.x - n.width / 2},${n.y - n.height / 2})`}
+               onPointerDown={(e) => onPointerDown(e, n)}
+               onDoubleClick={() => setFocused(focused === n.id ? null : n.id)}
+            >
+              <rect width={n.width} height={n.height} rx={20} fill={typeColor[n.type]} />
+              <title>{`${n.title} (${n.type})`}</title>
+              <text x={n.width/2} y={n.height/2} textAnchor="middle" dominantBaseline="middle" fill="#fff" fontSize="12">
+                {n.title.length > 20 ? n.title.slice(0,20)+"…" : n.title}
+              </text>
+            </g>
+          ))}
+        </g>
+      </svg>
+      <div className="absolute top-2 right-2 flex gap-2">
+        <Button size="sm" onClick={() => zoomRef.current.scaleBy(select(svgRef.current!), 1.2)}>Zoom In</Button>
+        <Button size="sm" onClick={() => zoomRef.current.scaleBy(select(svgRef.current!), 0.8)}>Zoom Out</Button>
+        <Button size="sm" onClick={handleReset}>Reset</Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/backlog/useAutoFit.test.ts
+++ b/frontend/src/components/backlog/useAutoFit.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { computeFit } from './useAutoFit';
+
+describe('computeFit', () => {
+  it('centers box inside container', () => {
+    const res = computeFit({ width: 200, height: 100 }, { x: 0, y: 0, width: 100, height: 50 });
+    expect(res.scale).toBe(2);
+    expect(res.x).toBe(0);
+    expect(res.y).toBe(0);
+  });
+
+  it('limits scale to 2.5', () => {
+    const res = computeFit({ width: 1000, height: 1000 }, { x: 0, y: 0, width: 10, height: 10 });
+    expect(res.scale).toBe(2.5);
+  });
+});

--- a/frontend/src/components/backlog/useAutoFit.ts
+++ b/frontend/src/components/backlog/useAutoFit.ts
@@ -1,0 +1,21 @@
+import { RefObject, useCallback } from 'react';
+import { select } from 'd3-selection';
+
+export interface BBox { x: number; y: number; width: number; height: number; }
+
+export function computeFit(container: { width: number; height: number }, box: BBox) {
+  const scale = Math.min(container.width / box.width, container.height / box.height, 2.5);
+  const x = (container.width - box.width * scale) / 2 - box.x * scale;
+  const y = (container.height - box.height * scale) / 2 - box.y * scale;
+  return { scale, x, y };
+}
+
+export function useAutoFit(svgRef: RefObject<SVGSVGElement>) {
+  return useCallback((box: BBox) => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    const rect = svg.getBoundingClientRect();
+    const { scale, x, y } = computeFit(rect, box);
+    select(svg).select('g').attr('transform', `translate(${x},${y}) scale(${scale})`);
+  }, [svgRef]);
+}

--- a/frontend/src/lib/layout.test.ts
+++ b/frontend/src/lib/layout.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+vi.mock('./api', () => ({
+  http: vi.fn(),
+}));
+
+import { getLayout, saveLayout } from './layout';
+import { http } from './api';
+
+const fetchMock = http as unknown as ReturnType<typeof vi.fn>;
+
+describe('layout api helpers', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('gets layout', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: () => Promise.resolve({ nodes: [{ item_id: 1, x: 0, y: 0 }] }) });
+    const nodes = await getLayout(5);
+    expect(fetchMock).toHaveBeenCalledWith('/projects/5/layout');
+    expect(nodes).toHaveLength(1);
+  });
+
+  it('saves layout', async () => {
+    fetchMock.mockResolvedValue({ ok: true });
+    await saveLayout(2, [{ item_id: 1, x: 1, y: 1 }]);
+    expect(fetchMock).toHaveBeenCalledWith('/projects/2/layout', expect.objectContaining({ method: 'PUT' }));
+  });
+
+  it('throws on error', async () => {
+    fetchMock.mockResolvedValue({ ok: false });
+    await expect(getLayout(1)).rejects.toThrow();
+  });
+});

--- a/frontend/src/lib/layout.ts
+++ b/frontend/src/lib/layout.ts
@@ -1,0 +1,28 @@
+import { http } from '@/lib/api';
+
+export interface LayoutNode {
+  item_id: number;
+  x: number;
+  y: number;
+  pinned?: boolean;
+}
+
+export async function getLayout(projectId: number): Promise<LayoutNode[]> {
+  const res = await http(`/projects/${projectId}/layout`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch layout');
+  }
+  const data = await res.json();
+  return Array.isArray(data.nodes) ? data.nodes : [];
+}
+
+export async function saveLayout(projectId: number, nodes: LayoutNode[]): Promise<void> {
+  const res = await http(`/projects/${projectId}/layout`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ nodes }),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to save layout');
+  }
+}


### PR DESCRIPTION
## Summary
- visualize backlog in hybrid dagre/d3-force layout with zoom, drag and persistence
- auto-fit and layout storage helpers
- add dagre and d3 dependencies

## Testing
- `pnpm test --run src/lib/layout.test.ts src/components/backlog/useAutoFit.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b49a945fdc8330b6cf14ebd978e5d1