### PR TITLE
feat: document management tools

### DIFF
--- a/agents/planner.py
+++ b/agents/planner.py
@@ -47,4 +47,10 @@ CONSTRAINTS:
 - Final response should be concise and include affected item IDs
 
 Available tools: create_item, update_item, find_item, get_item, list_items, delete_item, move_item, summarize_project, bulk_create_features
+
+You also have tools to manage project documents:
+- list_documents(project_id): list all documents for the current project.
+- search_documents(project_id, query): retrieve the most relevant passages from attached documents.
+- get_document(doc_id): fetch the full text of a small document when needed.
+Use these whenever the user mentions a PDF, requirements, 'cahier des charges', or asks for information likely contained in attached files. Prefer search_documents to avoid loading large texts.
 """

--- a/agents/tools.py
+++ b/agents/tools.py
@@ -72,10 +72,30 @@ class BulkCreateFeaturesArgs(BaseModel):
     parent_id: int
     items: List[Dict[str, Optional[str]]]
 
+class ListDocsArgs(BaseModel):
+    project_id: int
+
+class SearchDocsArgs(BaseModel):
+    project_id: int
+    query: str
+
+class GetDocArgs(BaseModel):
+    doc_id: int
+
 # ---------- HANDLERS réels ----------
 from .handlers import (
-    create_item_tool, update_item_tool, find_item_tool, get_item_tool, list_items_tool,
-    delete_item_tool, move_item_tool, summarize_project_tool, bulk_create_features_tool,
+    create_item_tool,
+    update_item_tool,
+    find_item_tool,
+    get_item_tool,
+    list_items_tool,
+    delete_item_tool,
+    move_item_tool,
+    summarize_project_tool,
+    bulk_create_features_tool,
+    list_documents_handler,
+    search_documents_handler,
+    get_document_handler,
 )
 
 def _sanitize(obj: Any) -> Any:
@@ -156,6 +176,9 @@ TOOLS = [
     _mk_tool("move_item", "Reparent an item (hierarchy enforced).", MoveItemArgs),
     _mk_tool("summarize_project", "Summarize the project tree and counts.", SummarizeProjectArgs),
     _mk_tool("bulk_create_features", "Create multiple Features under a parent; skip duplicates.", BulkCreateFeaturesArgs),
+    _mk_tool("list_documents", "List documents in the project.", ListDocsArgs),
+    _mk_tool("search_documents", "Search relevant passages in project documents.", SearchDocsArgs),
+    _mk_tool("get_document", "Get full text content of a document by ID.", GetDocArgs),
 ]
 
 # On conserve HANDLERS exporté si utilisé ailleurs
@@ -169,4 +192,7 @@ HANDLERS = {
     "move_item": move_item_tool,
     "summarize_project": summarize_project_tool,
     "bulk_create_features": bulk_create_features_tool,
+    "list_documents": list_documents_handler,
+    "search_documents": search_documents_handler,
+    "get_document": get_document_handler,
 }

--- a/orchestrator/crud.py
+++ b/orchestrator/crud.py
@@ -549,8 +549,13 @@ def get_all_chunks_for_project(project_id: int) -> List[dict]:
             "filename": row["filename"],
             "project_id": row["project_id"]
         })
-    
+
     return chunks
+
+
+def get_all_document_chunks_for_project(project_id: int) -> List[dict]:
+    """Compatibility wrapper for older naming."""
+    return get_all_chunks_for_project(project_id)
 
 def delete_document_chunks(doc_id: int) -> None:
     """Delete all chunks for a document."""

--- a/tests/test_document_tools.py
+++ b/tests/test_document_tools.py
@@ -1,0 +1,63 @@
+import pytest
+
+from orchestrator import crud
+from orchestrator.models import ProjectCreate
+from agents.handlers import (
+    list_documents_handler,
+    search_documents_handler,
+    get_document_handler,
+)
+import agents.handlers as handlers
+
+
+def setup(tmp_path, monkeypatch):
+    db = tmp_path / "db.sqlite"
+    monkeypatch.setattr(crud, "DATABASE_URL", str(db))
+    crud.init_db()
+    project = crud.create_project(ProjectCreate(name="Proj", description=None))
+    return project
+
+
+@pytest.mark.asyncio
+async def test_list_documents_handler(tmp_path, monkeypatch):
+    project = setup(tmp_path, monkeypatch)
+    crud.create_document(project.id, "doc.txt", "content", None, filepath=None)
+    res = await list_documents_handler({"project_id": project.id})
+    assert res["ok"] and len(res["documents"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_document_handler(tmp_path, monkeypatch):
+    project = setup(tmp_path, monkeypatch)
+    doc = crud.create_document(project.id, "doc.txt", "content", None, filepath=None)
+    res = await get_document_handler({"doc_id": doc.id})
+    assert res["ok"] and res["content"] == "content"
+    missing = await get_document_handler({"doc_id": 999})
+    assert not missing["ok"]
+
+
+@pytest.mark.asyncio
+async def test_search_documents_handler(tmp_path, monkeypatch):
+    project = setup(tmp_path, monkeypatch)
+    doc = crud.create_document(project.id, "doc.txt", "full", None, filepath=None)
+    crud.create_document_chunks(
+        doc.id,
+        [
+            {"text": "login page", "chunk_index": 0, "embedding": [1.0, 0.0]},
+            {"text": "logout", "chunk_index": 1, "embedding": [0.0, 1.0]},
+        ],
+    )
+
+    monkeypatch.setattr(handlers, "embed_text", lambda q: [1.0, 0.0])
+    monkeypatch.setattr(
+        handlers,
+        "cosine_similarity",
+        lambda a, b: sum(x * y for x, y in zip(a, b)),
+    )
+
+    res = await search_documents_handler({"project_id": project.id, "query": "login"})
+    assert res["ok"] and res["matches"][0]["text"] == "login page"
+
+    empty = await search_documents_handler({"project_id": project.id + 1, "query": "x"})
+    assert empty["ok"] and empty["matches"] == []
+


### PR DESCRIPTION
## Summary
- add list_documents, search_documents and get_document tools
- extend planner prompt for document retrieval
- expose CRUD helper and handlers with tests

## Testing
- `pytest tests/test_document_tools.py -q`
- `pytest -q` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68b56d655ed48330bf6130517a280a2d