### PR TITLE
feat: add text chunking and embedding pipeline

### DIFF
--- a/agents/embeddings.py
+++ b/agents/embeddings.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+from __future__ import annotations
+
+"""Utilities for chunking text, embedding via OpenAI, and cosine similarity."""
+import logging
+import os
+from typing import List
+
+import httpx
+import numpy as np
+import tiktoken
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
+logger = logging.getLogger(__name__)
+
+
+def _tokenize_len(text: str, model: str = "text-embedding-3-small") -> int:
+    enc = tiktoken.get_encoding("cl100k_base")
+    return len(enc.encode(text or ""))
+
+
+def chunk_text(text: str, target_tokens: int = 400, overlap_tokens: int = 60) -> List[str]:
+    """Split text into overlapping chunks based on token count."""
+    if not text:
+        return []
+    enc = tiktoken.get_encoding("cl100k_base")
+    toks = enc.encode(text)
+    chunks: List[str] = []
+    i = 0
+    n = len(toks)
+    while i < n:
+        j = min(i + target_tokens, n)
+        chunk = enc.decode(toks[i:j])
+        chunks.append(chunk.strip())
+        step = j - i
+        i = j - overlap_tokens if step > overlap_tokens else j
+    return [c for c in chunks if c]
+
+
+async def embed_texts(texts: List[str], model: str = "text-embedding-3-small") -> List[List[float]]:
+    """Embed a list of texts using OpenAI's embeddings API.
+
+    Returns empty lists when the API key is missing or requests fail.
+    """
+    if not texts:
+        return []
+    if not OPENAI_API_KEY or OPENAI_API_KEY.startswith("sk-test"):
+        logger.warning("OPENAI_API_KEY missing; returning empty embeddings")
+        return [[] for _ in texts]
+
+    headers = {
+        "Authorization": f"Bearer {OPENAI_API_KEY}",
+        "Content-Type": "application/json",
+    }
+    out: List[List[float]] = []
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        for i in range(0, len(texts), 96):
+            batch = texts[i : i + 96]
+            body = {"model": model, "input": batch}
+            try:
+                r = await client.post(
+                    "https://api.openai.com/v1/embeddings", headers=headers, json=body
+                )
+                r.raise_for_status()
+                data = r.json()
+                out.extend([d["embedding"] for d in data.get("data", [])])
+            except httpx.HTTPError as exc:  # pragma: no cover - network failure
+                logger.warning("embedding request failed: %s", exc)
+                out.extend([[] for _ in batch])
+    return out
+
+
+def cosine_similarity(a: List[float], b: List[float]) -> float:
+    va = np.array(a, dtype=np.float32)
+    vb = np.array(b, dtype=np.float32)
+    denom = float(np.linalg.norm(va) * np.linalg.norm(vb))
+    if denom == 0.0:
+        return 0.0
+    return float(np.dot(va, vb) / denom)
+
+
+async def embed_text(text: str) -> List[float]:
+    res = await embed_texts([text])
+    return res[0] if res else []

--- a/orchestrator/crud.py
+++ b/orchestrator/crud.py
@@ -153,6 +153,9 @@ def init_db():
         ")"
     )
     conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_document_chunks_doc ON document_chunks(doc_id)"
+    )
+    conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_document_chunks_doc_chunk ON document_chunks(doc_id, chunk_index)"
     )
     conn.execute(
@@ -425,6 +428,35 @@ def get_documents(project_id: int) -> List[Document]:
 
 
 # Document chunks CRUD operations
+
+def upsert_document_chunks(doc_id: int, chunks: list[tuple[int, str, list[float]]]) -> int:
+    """Upsert chunk records for a document.
+
+    Each chunk tuple is (chunk_index, text, embedding_list).
+    Embeddings are stored as JSON strings. Returns number of processed chunks.
+    """
+    if not chunks:
+        return 0
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    count = 0
+    try:
+        for idx, text, emb in chunks:
+            cursor.execute(
+                """
+                INSERT OR REPLACE INTO document_chunks (id, doc_id, chunk_index, text, embedding)
+                VALUES (
+                    COALESCE((SELECT id FROM document_chunks WHERE doc_id=? AND chunk_index=?), NULL),
+                    ?, ?, ?, ?
+                )
+                """,
+                (doc_id, idx, doc_id, idx, text, json.dumps(emb)),
+            )
+            count += 1
+        conn.commit()
+    finally:
+        conn.close()
+    return count
 
 def create_document_chunks(doc_id: int, chunks_data: List[dict]) -> List[int]:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ pymupdf = "^1.25.1"
 python-docx = "^1.1.2"
 pytesseract = "^0.3.13"
 pillow = "^10.4.0"
+tiktoken = "^0.7.0"
+numpy = "^2.1.3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.1"

--- a/tests/test_agents_embeddings.py
+++ b/tests/test_agents_embeddings.py
@@ -1,0 +1,36 @@
+import importlib
+import pytest
+
+from agents import embeddings as emb
+
+
+class DummyEnc:
+    def encode(self, text):
+        return [0] * len(text.split())
+    def decode(self, toks):
+        return " ".join("x" for _ in toks)
+
+
+def test_chunk_text_empty(monkeypatch):
+    monkeypatch.setattr(emb.tiktoken, "get_encoding", lambda name: DummyEnc())
+    assert emb.chunk_text("", target_tokens=10) == []
+
+
+def test_chunk_text_long(monkeypatch):
+    monkeypatch.setattr(emb.tiktoken, "get_encoding", lambda name: DummyEnc())
+    text = "word " * 500
+    chunks = emb.chunk_text(text, target_tokens=50, overlap_tokens=10)
+    assert len(chunks) > 1
+
+
+@pytest.mark.asyncio
+async def test_embed_texts_missing_key(monkeypatch):
+    monkeypatch.setattr(emb, "OPENAI_API_KEY", "")
+    res = await emb.embed_texts(["a", "b"])
+    assert res == [[], []]
+
+
+def test_cosine_similarity():
+    assert emb.cosine_similarity([1, 0], [1, 0]) == pytest.approx(1.0)
+    assert emb.cosine_similarity([1, 0], [0, 1]) == pytest.approx(0.0, abs=1e-6)
+    assert emb.cosine_similarity([0, 0], [1, 2]) == 0.0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -262,12 +262,19 @@ async def test_document_upload_and_listing(tmp_path, monkeypatch):
     crud.init_db()
     project = crud.create_project(ProjectCreate(name="P", description=None))
 
-    from orchestrator import embedding_service
+    from agents import embeddings
 
-    async def fake_embed(*args, **kwargs):
-        return []
+    async def fake_embed(texts):
+        return [[] for _ in texts]
 
-    monkeypatch.setattr(embedding_service, "embed_document_text", fake_embed)
+    monkeypatch.setattr(embeddings, "embed_texts", fake_embed)
+    monkeypatch.setattr(embeddings, "chunk_text", lambda text, **_: [text])
+    class DummyEnc:
+        def encode(self, text):
+            return [0] * len(text.split())
+        def decode(self, toks):
+            return " ".join("x" for _ in toks)
+    monkeypatch.setattr(embeddings.tiktoken, "get_encoding", lambda name: DummyEnc())
 
     async with AsyncClient(transport=transport, base_url=BASE_URL) as ac:
         files = {"file": ("note.txt", b"hello", "text/plain")}
@@ -291,12 +298,19 @@ async def test_pdf_content_extraction(tmp_path, monkeypatch):
     crud.init_db()
     project = crud.create_project(ProjectCreate(name="P", description=None))
 
-    from orchestrator import embedding_service
+    from agents import embeddings
 
-    async def fake_embed(*args, **kwargs):
-        return []
+    async def fake_embed(texts):
+        return [[] for _ in texts]
 
-    monkeypatch.setattr(embedding_service, "embed_document_text", fake_embed)
+    monkeypatch.setattr(embeddings, "embed_texts", fake_embed)
+    monkeypatch.setattr(embeddings, "chunk_text", lambda text, **_: [text])
+    class DummyEnc:
+        def encode(self, text):
+            return [0] * len(text.split())
+        def decode(self, toks):
+            return " ".join("x" for _ in toks)
+    monkeypatch.setattr(embeddings.tiktoken, "get_encoding", lambda name: DummyEnc())
 
     pdf = fitz.open()
     page = pdf.new_page()

--- a/tests/test_upsert_document_chunks.py
+++ b/tests/test_upsert_document_chunks.py
@@ -1,0 +1,32 @@
+import pytest
+from orchestrator import crud
+from orchestrator.models import ProjectCreate
+
+
+@pytest.fixture
+def doc(tmp_path, monkeypatch):
+    db = tmp_path / "db.sqlite"
+    monkeypatch.setattr(crud, "DATABASE_URL", str(db))
+    crud.init_db()
+    project = crud.create_project(ProjectCreate(name="P", description=None))
+    return crud.create_document(project.id, "f.txt", "hello world", None)
+
+
+def test_upsert_idempotent(doc):
+    payload = [(0, "first", [0.1, 0.2]), (1, "second", [0.3, 0.4])]
+    assert crud.upsert_document_chunks(doc.id, payload) == 2
+    chunks = crud.get_document_chunks(doc.id)
+    assert len(chunks) == 2
+
+    # update existing chunk 0
+    payload2 = [(0, "updated", [0.9, 0.9])]
+    crud.upsert_document_chunks(doc.id, payload2)
+    chunks = crud.get_document_chunks(doc.id)
+    assert len(chunks) == 2
+    chunk0 = [c for c in chunks if c["chunk_index"] == 0][0]
+    assert chunk0["text"] == "updated"
+    assert chunk0["embedding"] == [0.9, 0.9]
+
+
+def test_upsert_empty(doc):
+    assert crud.upsert_document_chunks(doc.id, []) == 0


### PR DESCRIPTION
## Summary
- add reusable chunking, OpenAI embedding, and cosine similarity utilities
- store document chunks with upsert helper and index
- process uploaded docs by chunking, embedding, and persisting vectors

## Testing
- `pytest tests/test_api.py::test_document_upload_and_listing -q`
- `pytest tests/test_embedding_api.py -q`
- `pytest tests/test_agents_embeddings.py tests/test_upsert_document_chunks.py -q`
- `pytest -q` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68b56fce69508330b90360fe8c5b2760