### PR TITLE
feat: add document analysis trigger

### DIFF
--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { getApiBaseUrl } from './api';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { getApiBaseUrl, runAgent } from './api';
 
 describe('getApiBaseUrl', () => {
   beforeEach(() => {
@@ -18,5 +18,42 @@ describe('getApiBaseUrl', () => {
   it('handles relative base', () => {
     process.env.NEXT_PUBLIC_API_BASE_URL = '/backend/';
     expect(getApiBaseUrl()).toBe('/backend');
+  });
+});
+
+describe('runAgent', () => {
+  const payload = { project_id: 1, objective: 'test' };
+
+  it('posts payload and returns response json', async () => {
+    const json = vi.fn().mockResolvedValue({ id: 1 });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json });
+    (global as any).fetch = fetchMock;
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://api';
+
+    const data = await runAgent(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith('http://api/agent/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    expect(data).toEqual({ id: 1 });
+  });
+
+  it('throws when response not ok', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false });
+    (global as any).fetch = fetchMock;
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://api';
+
+    await expect(runAgent(payload)).rejects.toThrow('Agent run failed');
+  });
+
+  it('propagates network errors', async () => {
+    const err = new Error('network');
+    const fetchMock = vi.fn().mockRejectedValue(err);
+    (global as any).fetch = fetchMock;
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://api';
+
+    await expect(runAgent(payload)).rejects.toThrow(err);
   });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10,3 +10,13 @@ export function http(path: string, init?: RequestInit) {
   const url = `${base}${path.startsWith('/') ? path : '/' + path}`;
   return fetch(url, init);
 }
+
+export async function runAgent(payload: { project_id: number; objective: string }) {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/agent/run`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw new Error('Agent run failed');
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add runAgent API helper to start agent runs
- enable document analysis via new Analyze button in DocumentList
- cover new API and UI behaviors with tests

## Testing
- `npm test` *(fails: useBacklog must be used within BacklogProvider)*
- `npx vitest run src/lib/api.test.ts src/components/__tests__/DocumentList.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b587c1d650833081562487a166caf6