### PR TITLE
Handle project ID when creating runs

### DIFF
--- a/api/ws.py
+++ b/api/ws.py
@@ -6,10 +6,12 @@ from uuid import uuid4
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from starlette.websockets import WebSocketState
 
+import logging
 from orchestrator.core_loop import run_chat_tools
 from orchestrator import crud, stream
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 async def close_ws(ws: WebSocket, code: int, reason: str | None = None) -> None:
@@ -78,5 +80,5 @@ async def stream_chat(ws: WebSocket):
         if run_id:
             stream.discard(run_id)
     except Exception as e:  # pragma: no cover - runtime errors
-        msg = (str(e) or "internal error")[:120]
-        await close_ws(ws, code=1011, reason=msg)
+        logger.exception("WS error")
+        await close_ws(ws, code=1011, reason=str(e))


### PR DESCRIPTION
## Summary
- persist run IDs alongside project identifiers and track steps
- add robust WebSocket error handling and avoid passing raw socket to run creation
- ensure planner and API endpoints return run IDs and work with string IDs

## Testing
- `pytest tests/test_runs.py::test_run_creation_and_retrieval -q`
- `pytest tests/test_runs.py::test_finish_run_updates_status_and_render -q`
- `pytest tests/test_api.py::test_ws_stream_new_run -q` *(fails: [])*


------
https://chatgpt.com/codex/tasks/task_e_68b606932824833082ad91bda6f6d440