### PR TITLE
feat: infer features from document matches

### DIFF
--- a/agents/tools.py
+++ b/agents/tools.py
@@ -197,7 +197,11 @@ TOOLS = [
     _mk_tool("list_documents", "List documents in the project.", ListDocsArgs),
     _mk_tool("search_documents", "Search relevant passages in project documents.", SearchDocsArgs),
     _mk_tool("get_document", "Get full text content of a document by ID.", GetDocArgs),
-    _mk_tool("draft_features_from_matches", "Draft Feature items array from document matches. It returns {items:[...]}, not writing to DB.", DraftFeaturesArgs),
+    _mk_tool(
+        "draft_features_from_matches",
+        "Infer and create Feature backlog items from project documents. Returns {items:[{id,title}]}.",
+        DraftFeaturesArgs,
+    ),
 ]
 
 # On conserve HANDLERS exporté si utilisé ailleurs

--- a/prompts/features_from_excerpts.yaml
+++ b/prompts/features_from_excerpts.yaml
@@ -1,0 +1,17 @@
+template: |
+  You are a senior product manager. You receive EXCERPTS from a French RFP-like document (cahier des charges) about an AI Assistant for backlog management and document Q&A.
+  
+  Task:
+  - From the EXCERPTS, infer 5 to 10 PRODUCT FEATURES (not user stories):
+    - Each feature must have: title, objective, business_value, 2-4 acceptance_criteria (testable), parent_hint if obvious (e.g., Epic).
+  - Derive features from sections like "Cas d’usage", "Périmètre fonctionnel", "Périmètre technique", "Jalons", "Critères de réussite".
+  - Output STRICT JSON matching the provided schema. No prose outside the JSON.
+  
+  Guidelines:
+  - Titles must be concise and actionable (<=120 chars).
+  - Acceptance criteria must be verifiable (avoid vague wording).
+  - If EXCERPTS are not enough, generalize cautiously from typical capabilities described.
+  - Stay in French.
+  EXCERPTS:
+  {{excerpts}}
+  Return ONLY the JSON.

--- a/tests/test_draft_features_from_matches.py
+++ b/tests/test_draft_features_from_matches.py
@@ -1,0 +1,108 @@
+import asyncio
+import pytest
+from types import SimpleNamespace
+
+from agents.handlers import draft_features_from_matches_handler
+
+
+@pytest.fixture(autouse=True)
+def patch_graph():
+    yield
+
+
+def test_draft_features_creates_items(monkeypatch):
+    # prepare chunks
+    fake_chunks = [
+        {"doc_id": 1, "text": "Cas d'usage: gérer le backlog", "embedding": [0.1, 0.2]},
+    ]
+    monkeypatch.setattr(
+        "agents.handlers.crud.get_all_document_chunks_for_project",
+        lambda project_id: fake_chunks,
+    )
+    async def fake_embed(q):
+        return [0.1, 0.2]
+
+    monkeypatch.setattr("agents.handlers.embed_text", fake_embed)
+    monkeypatch.setattr("agents.handlers.cosine_similarity", lambda a, b: 0.9)
+
+    # dummy llm always returns one feature
+    class DummyLLM:
+        def __init__(self, *a, **kw):
+            pass
+
+        def invoke(self, msgs):
+            return SimpleNamespace(
+                content=(
+                    '{"features":[{"title":"Gestion du backlog","objective":"Obj","business_value":"Val","acceptance_criteria":["crit1","crit2"],"parent_hint":null}]}'
+                )
+            )
+
+    monkeypatch.setattr("agents.handlers.ChatOpenAI", DummyLLM)
+    created = []
+
+    def fake_create_item(item):
+        created.append(item)
+        return SimpleNamespace(id=len(created), title=item.title, parent_id=item.parent_id)
+
+    monkeypatch.setattr("agents.handlers.crud.create_item", fake_create_item)
+    monkeypatch.setattr("agents.handlers.crud.get_items", lambda project_id, type=None: [])
+
+    res = asyncio.run(draft_features_from_matches_handler({"project_id": 1, "doc_query": "backlog", "k": 1}))
+    assert res["ok"] is True
+    assert res["items"][0]["title"] == "Gestion du backlog"
+    assert created and created[0].title == "Gestion du backlog"
+
+
+def test_draft_features_no_matches(monkeypatch):
+    monkeypatch.setattr(
+        "agents.handlers.crud.get_all_document_chunks_for_project",
+        lambda project_id: [],
+    )
+    res = asyncio.run(draft_features_from_matches_handler({"project_id": 1, "doc_query": "none"}))
+    assert res["ok"] and res["items"] == []
+
+
+def test_draft_features_fallback(monkeypatch):
+    fake_chunks = [
+        {"doc_id": 2, "text": "Périmètre fonctionnel", "embedding": [0.1]},
+    ]
+    monkeypatch.setattr(
+        "agents.handlers.crud.get_all_document_chunks_for_project",
+        lambda project_id: fake_chunks,
+    )
+    async def fake_embed(q):
+        return [0.1]
+
+    monkeypatch.setattr("agents.handlers.embed_text", fake_embed)
+    monkeypatch.setattr("agents.handlers.cosine_similarity", lambda a, b: 0.9)
+
+    class DummyLLMFallback:
+        def __init__(self, *a, **kw):
+            self.calls = 0
+
+        def invoke(self, msgs):
+            self.calls += 1
+            if self.calls == 1:
+                return SimpleNamespace(content='{"features": []}')
+            return SimpleNamespace(
+                content=(
+                    '{"features":[{"title":"Analyse", "objective":"Obj","business_value":"Val","acceptance_criteria":["c1","c2"],"parent_hint":null}]}'
+                )
+            )
+
+    dummy = DummyLLMFallback()
+    monkeypatch.setattr("agents.handlers.ChatOpenAI", lambda *a, **kw: dummy)
+    monkeypatch.setattr(
+        "agents.handlers.crud.get_document",
+        lambda doc_id: {"content": "Texte complet"},
+    )
+    created = []
+    monkeypatch.setattr(
+        "agents.handlers.crud.create_item",
+        lambda item: created.append(item) or SimpleNamespace(id=len(created), title=item.title),
+    )
+    monkeypatch.setattr("agents.handlers.crud.get_items", lambda project_id, type=None: [])
+
+    res = asyncio.run(draft_features_from_matches_handler({"project_id": 1, "doc_query": "x", "k": 1}))
+    assert res["ok"] and res["items"][0]["title"] == "Analyse"
+    assert len(created) == 1


### PR DESCRIPTION
## Summary
- enhance `draft_features_from_matches` to retrieve more document excerpts and create Feature backlog items
- add prompt for feature extraction from RFP-like excerpts
- cover feature drafting handler with dedicated tests

## Testing
- `pytest tests/test_draft_features_from_matches.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain')*


------
https://chatgpt.com/codex/tasks/task_e_68b6917fd9488330b1bc57a8efe0d9f7