### PR TITLE
feat: generate backlog items from parent

### DIFF
--- a/agents/tools.py
+++ b/agents/tools.py
@@ -1,5 +1,5 @@
 from typing import Optional, Literal, List, Dict, Any
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ValidationError, Field
 import logging
 try:
     from langchain.tools import StructuredTool
@@ -87,6 +87,12 @@ class DraftFeaturesArgs(BaseModel):
     doc_query: str
     k: int = 6  # number of features to draft
 
+class GenerateItemsArgs(BaseModel):
+    project_id: int = Field(..., description="Project ID")
+    parent_id: int = Field(..., description="Parent item ID")
+    target_type: Literal["Feature", "US", "UC"]
+    n: int | None = Field(6, description="How many items to generate (3..10)")
+
 # ---------- HANDLERS réels ----------
 from .handlers import (  # noqa: E402 - handlers import requires models above
     create_item_tool,
@@ -102,6 +108,7 @@ from .handlers import (  # noqa: E402 - handlers import requires models above
     search_documents_handler,
     get_document_handler,
     draft_features_from_matches_handler,
+    generate_items_from_parent_handler,
 )
 
 def _sanitize(obj: Any) -> Any:
@@ -194,6 +201,11 @@ TOOLS = [
     _mk_tool("move_item", "Reparent an item (hierarchy enforced).", MoveItemArgs),
     _mk_tool("summarize_project", "Summarize the project tree and counts.", SummarizeProjectArgs),
     _mk_tool("bulk_create_features", "Create multiple Features under a parent; skip duplicates.", BulkCreateFeaturesArgs),
+    _mk_tool(
+        "generate_items_from_parent",
+        "Generate backlog items (Feature, US, or UC) under a parent item.",
+        GenerateItemsArgs,
+    ),
     _mk_tool("list_documents", "List documents in the project.", ListDocsArgs),
     _mk_tool("search_documents", "Search relevant passages in project documents.", SearchDocsArgs),
     _mk_tool("get_document", "Get full text content of a document by ID.", GetDocArgs),
@@ -219,4 +231,5 @@ HANDLERS = {
     "search_documents": search_documents_handler,
     "get_document": get_document_handler,
     "draft_features_from_matches": draft_features_from_matches_handler,
+    "generate_items_from_parent": generate_items_from_parent_handler,
 }

--- a/tests/test_generate_items_from_parent.py
+++ b/tests/test_generate_items_from_parent.py
@@ -1,0 +1,95 @@
+import asyncio
+from types import SimpleNamespace
+import pytest
+
+from agents.handlers import (
+    _validate_payload,
+    _dedup_titles,
+    generate_items_from_parent_handler,
+)
+
+
+def test_validate_payload_us_filters_invalid():
+    payload = {
+        "items": [
+            {
+                "title": "A",
+                "as_a": "user",
+                "i_want": "x",
+                "so_that": "y",
+                "acceptance_criteria": ["one"],
+            },
+            {
+                "title": "B",
+                "as_a": "user",
+                "i_want": "x",
+                "so_that": "y",
+                "acceptance_criteria": ["one", "two"],
+            },
+        ]
+    }
+    out = _validate_payload("US", payload)
+    assert len(out) == 1
+    assert out[0]["title"] == "B"
+
+
+@pytest.mark.asyncio
+async def test_dedup_titles_removes_duplicates():
+    candidates = [{"title": "Gestion du backlog"}, {"title": "Analyse"}]
+    existing = [{"title": "Gestion du backlog"}]
+    out = await _dedup_titles(candidates, existing)
+    assert out == [{"title": "Analyse"}]
+
+
+@pytest.mark.asyncio
+async def test_generate_items_from_parent_handler_creates_items(monkeypatch):
+    created = []
+
+    monkeypatch.setattr(
+        "agents.handlers.crud.get_item",
+        lambda item_id: SimpleNamespace(
+            id=item_id, type="Feature", title="Feat", description="", project_id=1
+        ),
+    )
+    monkeypatch.setattr(
+        "agents.handlers.crud.get_items",
+        lambda project_id, type=None, limit=200, offset=0: [
+            SimpleNamespace(id=2, type="US", title="Story existante", parent_id=1)
+        ],
+    )
+    monkeypatch.setattr(
+        "agents.handlers.crud.create_item",
+        lambda item: created.append(item) or SimpleNamespace(id=len(created), title=item.title),
+    )
+    monkeypatch.setattr(
+        "agents.handlers._build_llm_json_object",
+        lambda: SimpleNamespace(
+            invoke=lambda msgs: SimpleNamespace(
+                content="{\n  \"parent_id\": 1, \n  \"type\": \"US\", \n  \"items\": [\n    {\"title\": \"Story existante\", \"as_a\": \"user\", \"i_want\": \"x\", \"so_that\": \"y\", \"acceptance_criteria\": [\"a\", \"b\"]},\n    {\"title\": \"Nouvelle story\", \"as_a\": \"user\", \"i_want\": \"x2\", \"so_that\": \"y2\", \"acceptance_criteria\": [\"a2\", \"b2\"], \"priority\": \"Could\", \"estimate\": 5}\n  ]\n}"
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "agents.handlers.search_documents_handler",
+        lambda args: {"ok": True, "matches": []},
+    )
+    monkeypatch.setattr(
+        "agents.handlers.summarize_project_tool",
+        lambda args: {"ok": True, "result": {"text": "ctx"}},
+    )
+
+    res = await generate_items_from_parent_handler(
+        {"project_id": 1, "parent_id": 1, "target_type": "US", "n": 3}
+    )
+    assert res["ok"] is True
+    assert len(res["items"]) == 1
+    assert res["items"][0]["title"] == "Nouvelle story"
+
+
+@pytest.mark.asyncio
+async def test_generate_items_from_parent_handler_bad_type():
+    res = await generate_items_from_parent_handler(
+        {"project_id": 1, "parent_id": 1, "target_type": "Task"}
+    )
+    assert res["ok"] is False
+    assert "Unsupported" in res["error"]


### PR DESCRIPTION
## Summary
- add `generate_items_from_parent` tool to create child features, stories or use cases using project context and docs
- implement robust handler with validation, deduplication, doc grounding and rate-limit backoff
- cover handler and helpers with tests

## Testing
- `pytest tests/test_generate_items_from_parent.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'docx')*


------
https://chatgpt.com/codex/tasks/task_e_68b6a78a41bc8330b2e3c23e49948460