### PR TITLE
feat: add scrollable dashboard layout component

### DIFF
--- a/frontend/src/components/DashboardLayout.test.tsx
+++ b/frontend/src/components/DashboardLayout.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import DashboardLayout from "./DashboardLayout";
+
+describe("DashboardLayout", () => {
+  it("renders header and footer", () => {
+    render(<DashboardLayout />);
+    expect(screen.getByText("Header")).toBeInTheDocument();
+    expect(screen.getByText("Footer")).toBeInTheDocument();
+  });
+
+  it("renders all backlog items", () => {
+    render(<DashboardLayout />);
+    expect(screen.getByText("Backlog Item 50")).toBeInTheDocument();
+  });
+
+  it("renders all messages", () => {
+    render(<DashboardLayout />);
+    expect(screen.getByText("Message 50")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/DashboardLayout.tsx
+++ b/frontend/src/components/DashboardLayout.tsx
@@ -1,0 +1,43 @@
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+export default function DashboardLayout() {
+  return (
+    <div className="flex h-dvh flex-col">
+      <header className="shrink-0 border-b p-4">Header</header>
+
+      <div className="grid flex-1 min-h-0 grid-cols-[16rem_1fr_20rem]">
+        <aside className="flex min-h-0 flex-col border-r">
+          <ScrollArea className="h-full p-4">
+            {Array.from({ length: 50 }).map((_, i) => (
+              <div key={i} className="py-1">
+                Sidebar Item {i + 1}
+              </div>
+            ))}
+          </ScrollArea>
+        </aside>
+
+        <section className="flex min-h-0 flex-col border-r">
+          <ScrollArea className="h-full p-4">
+            {Array.from({ length: 50 }).map((_, i) => (
+              <div key={i} className="py-1">
+                Backlog Item {i + 1}
+              </div>
+            ))}
+          </ScrollArea>
+        </section>
+
+        <section className="flex min-h-0 flex-col">
+          <ScrollArea className="h-full p-4">
+            {Array.from({ length: 50 }).map((_, i) => (
+              <div key={i} className="py-1">
+                Message {i + 1}
+              </div>
+            ))}
+          </ScrollArea>
+        </section>
+      </div>
+
+      <footer className="shrink-0 border-t p-4">Footer</footer>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/scroll-area.tsx
+++ b/frontend/src/components/ui/scroll-area.tsx
@@ -1,0 +1,11 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface ScrollAreaProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("overflow-y-auto", className)} {...props} />
+  )
+);
+ScrollArea.displayName = "ScrollArea";


### PR DESCRIPTION
## Summary
- add DashboardLayout with three scrollable columns
- provide fallback ScrollArea utility
- cover layout with basic render tests

## Testing
- `pnpm test` *(fails: TypeError in ProjectPanel and context errors)*
- `CI=1 pnpm test src/components/DashboardLayout.test.tsx`
- `pytest` *(fails: ModuleNotFoundError: dotenv, fastapi, pydantic, etc)*

------
https://chatgpt.com/codex/tasks/task_e_68b6be557bc083309bc2d5cd0a4e9477