### PR TITLE
feat(frontend): add backlog column components

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "react": "19.1.0",
     "react-aria-components": "^1.11.0",
     "react-dom": "19.1.0",
+    "react-virtuoso": "4.14.0",
     "sonner": "^2.0.7",
     "swr": "^2.3.4",
     "tailwind-merge": "^3.3.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -27,16 +27,16 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       d3-force:
-        specifier: ^3
+        specifier: ^3.0.0
         version: 3.0.0
       d3-selection:
-        specifier: ^3
+        specifier: ^3.0.0
         version: 3.0.0
       d3-zoom:
-        specifier: ^3
+        specifier: ^3.0.0
         version: 3.0.0
       dagre:
-        specifier: ^0.8
+        specifier: ^0.8.5
         version: 0.8.5
       lucide-react:
         specifier: ^0.525.0
@@ -53,6 +53,9 @@ importers:
       react-dom:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
+      react-virtuoso:
+        specifier: 4.14.0
+        version: 4.14.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -81,6 +84,9 @@ importers:
       '@testing-library/react':
         specifier: 16.3.0
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@types/dagre':
+        specifier: ^0.7.53
+        version: 0.7.53
       '@types/node':
         specifier: ^20
         version: 20.19.8
@@ -1857,6 +1863,9 @@ packages:
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
+  '@types/dagre@0.7.53':
+    resolution: {integrity: sha512-f4gkWqzPZvYmKhOsDnhq/R8mO4UMcKdxZo+i5SCkOU1wvGeHJeUXGIHeE9pnwGyPMDof1Vx5ZQo4nxpeg2TTVQ==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -3320,6 +3329,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-virtuoso@4.14.0:
+    resolution: {integrity: sha512-fR+eiCvirSNIRvvCD7ueJPRsacGQvUbjkwgWzBZXVq+yWypoH7mRUvWJzGHIdoRaCZCT+6mMMMwIG2S1BW3uwA==}
+    peerDependencies:
+      react: '>=16 || >=17 || >= 18 || >= 19'
+      react-dom: '>=16 || >=17 || >= 18 || >=19'
 
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
@@ -5898,6 +5913,8 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
 
+  '@types/dagre@0.7.53': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
@@ -7629,6 +7646,11 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.8
+
+  react-virtuoso@4.14.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   react@19.1.0: {}
 

--- a/frontend/src/components/BacklogColumn.tsx
+++ b/frontend/src/components/BacklogColumn.tsx
@@ -1,0 +1,26 @@
+import { BacklogItem, BacklogItemProps } from "./BacklogItem";
+
+interface BacklogColumnProps {
+  items: BacklogItemProps[];
+}
+
+export function BacklogColumn({ items }: BacklogColumnProps) {
+  return (
+    <div className="flex min-h-0 flex-col overflow-y-auto">
+      <div className="sticky top-0 z-10 flex items-center gap-2 border-b bg-background px-3 py-2">
+        <span className="font-medium">Backlog</span>
+        <input
+          placeholder="Search"
+          className="ml-auto h-7 w-32 rounded border px-2 py-1 text-sm"
+        />
+      </div>
+
+      <ul className="divide-y divide-border">
+        {items.map((item) => (
+          <BacklogItem key={item.id} {...item} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/frontend/src/components/BacklogColumnVirtuoso.tsx
+++ b/frontend/src/components/BacklogColumnVirtuoso.tsx
@@ -1,0 +1,31 @@
+import { Virtuoso } from "react-virtuoso";
+import { BacklogItem, BacklogItemProps } from "./BacklogItem";
+
+interface BacklogColumnVirtuosoProps {
+  items: BacklogItemProps[];
+}
+
+export function BacklogColumnVirtuoso({ items }: BacklogColumnVirtuosoProps) {
+  return (
+    <div className="flex flex-1 min-h-0 flex-col">
+      <Virtuoso
+        className="flex-1"
+        data={items}
+        overscan={200}
+        components={{
+          Header: () => (
+            <div className="sticky top-0 z-10 flex items-center gap-2 border-b bg-background px-3 py-2">
+              <span className="font-medium">Backlog</span>
+              <input
+                placeholder="Search"
+                className="ml-auto h-7 w-32 rounded border px-2 py-1 text-sm"
+              />
+            </div>
+          ),
+        }}
+        itemContent={(_, item) => <BacklogItem {...item} />}
+      />
+    </div>
+  );
+}
+

--- a/frontend/src/components/BacklogItem.tsx
+++ b/frontend/src/components/BacklogItem.tsx
@@ -1,0 +1,30 @@
+export interface BacklogItemProps {
+  id: string;
+  title: string;
+  status?: string;
+  tags?: string[];
+}
+
+export function BacklogItem({ title, status, tags }: BacklogItemProps) {
+  return (
+    <li className="flex items-center justify-between px-2 py-1 text-sm hover:bg-accent/50">
+      <span className="truncate">{title}</span>
+      <div className="ml-2 flex items-center gap-1">
+        {status && (
+          <span className="rounded bg-muted px-1 py-0.5 text-[10px] text-muted-foreground">
+            {status}
+          </span>
+        )}
+        {tags?.map((tag) => (
+          <span
+            key={tag}
+            className="rounded bg-secondary px-1 py-0.5 text-[10px] text-secondary-foreground"
+          >
+            {tag}
+          </span>
+        ))}
+      </div>
+    </li>
+  );
+}
+

--- a/frontend/src/components/__tests__/BacklogComponents.test.tsx
+++ b/frontend/src/components/__tests__/BacklogComponents.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react";
+import { BacklogItem } from "../BacklogItem";
+import { BacklogColumn } from "../BacklogColumn";
+import { BacklogColumnVirtuoso } from "../BacklogColumnVirtuoso";
+
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as any;
+
+global.IntersectionObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as any;
+
+describe("BacklogItem", () => {
+  it("renders title, status and tags", () => {
+    render(
+      <ul>
+        <BacklogItem
+          id="1"
+          title="Test Item"
+          status="Todo"
+          tags={["bug", "urgent"]}
+        />
+      </ul>
+    );
+    expect(screen.getByText("Test Item")).toBeInTheDocument();
+    expect(screen.getByText("Todo")).toBeInTheDocument();
+    expect(screen.getByText("bug")).toBeInTheDocument();
+    expect(screen.getByText("urgent")).toBeInTheDocument();
+  });
+
+  it("handles absence of status and tags", () => {
+    render(
+      <ul>
+        <BacklogItem id="2" title="Simple" />
+      </ul>
+    );
+    expect(screen.getByText("Simple")).toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+});
+
+describe("BacklogColumn", () => {
+  const items = [
+    { id: "1", title: "A" },
+    { id: "2", title: "B" },
+  ];
+
+  it("renders sticky header and items", () => {
+    render(<BacklogColumn items={items} />);
+    const header = screen.getByText("Backlog");
+    expect(header).toBeInTheDocument();
+    expect(header.parentElement).toHaveClass("sticky");
+    expect(screen.getAllByRole("listitem").length).toBe(2);
+  });
+
+  it("renders without items", () => {
+    render(<BacklogColumn items={[]} />);
+    expect(screen.queryAllByRole("listitem").length).toBe(0);
+  });
+});
+
+describe("BacklogColumnVirtuoso", () => {
+  const items = Array.from({ length: 3 }).map((_, i) => ({
+    id: String(i),
+    title: `Item ${i}`,
+  }));
+
+  it("renders header and list container", () => {
+    render(
+      <div style={{ height: 300 }}>
+        <BacklogColumnVirtuoso items={items} />
+      </div>
+    );
+    expect(screen.getByText("Backlog")).toBeInTheDocument();
+    expect(screen.getByTestId("virtuoso-item-list")).toBeInTheDocument();
+  });
+
+  it("handles empty items", () => {
+    render(
+      <div style={{ height: 300 }}>
+        <BacklogColumnVirtuoso items={[]} />
+      </div>
+    );
+    expect(screen.getByText("Backlog")).toBeInTheDocument();
+    expect(screen.getByTestId("virtuoso-item-list").childElementCount).toBe(0);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add compact BacklogItem component with dense tags
- implement scrollable BacklogColumn and virtualized BacklogColumnVirtuoso
- cover components with unit tests and add react-virtuoso dependency

## Testing
- `pnpm test src/components/__tests__/BacklogComponents.test.tsx`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68b6c2064d208330938712d4b918f3f4