### PR TITLE
feat(frontend): add conversation history UI

### DIFF
--- a/frontend/src/components/history/AgentPlanCard.tsx
+++ b/frontend/src/components/history/AgentPlanCard.tsx
@@ -1,0 +1,32 @@
+import { useCallback, useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+export function AgentPlanCard({ bullets, rationale }: { bullets: string[]; rationale?: string }) {
+  const [show, setShow] = useState(false);
+  const toggle = useCallback(() => setShow((s) => !s), []);
+  const onKey = useCallback(
+    (e: React.KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'r') {
+        toggle();
+        e.preventDefault();
+      }
+    },
+    [toggle]
+  );
+  return (
+    <div className="rounded-2xl border bg-white p-4 shadow-sm" onKeyDown={onKey} tabIndex={0}>
+      <div className="mb-2 text-sm font-semibold">Agent Plan (visible)</div>
+      <ul className="mb-2 list-disc pl-4 text-sm">
+        {bullets.map((b, i) => (
+          <li key={i}>{b}</li>
+        ))}
+      </ul>
+      {rationale && show && <p className="mb-2 text-sm text-muted-foreground">{rationale}</p>}
+      {rationale && (
+        <Button variant="ghost" size="sm" onClick={toggle} aria-expanded={show}>
+          {show ? 'Hide' : 'Show more'} (Ctrl+R)
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/history/ConversationHistoryPanel.tsx
+++ b/frontend/src/components/history/ConversationHistoryPanel.tsx
@@ -1,0 +1,32 @@
+import { useCallback, useState } from 'react';
+import type { HistoryRun, Step } from '@/types/history';
+import { UserPromptCard } from './UserPromptCard';
+import { AgentPlanCard } from './AgentPlanCard';
+import { ExecutionTimeline } from './ExecutionTimeline';
+import { FinalAnswerCard } from './FinalAnswerCard';
+import { RightFiltersDrawer, Filters } from './RightFiltersDrawer';
+
+export function ConversationHistoryPanel({ run }: { run: HistoryRun }) {
+  const [filters, setFilters] = useState<Filters>({ status: 'all', kind: 'all', time: '1h', group: 'run' });
+
+  const predicate = useCallback(
+    (s: Step) => {
+      if (filters.status !== 'all' && s.status !== filters.status) return false;
+      if (filters.kind !== 'all' && s.kind !== filters.kind) return false;
+      return true;
+    },
+    [filters]
+  );
+
+  return (
+    <div className="h-full flex gap-4">
+      <div className="flex-1 min-h-0 overflow-y-auto space-y-4">
+        <UserPromptCard prompt={run.userPrompt} time={run.startedAt} />
+        <AgentPlanCard bullets={run.agentPlan.bullets} rationale={run.agentPlan.rationale} />
+        <ExecutionTimeline steps={run.steps} filter={predicate} />
+        <FinalAnswerCard run={run} />
+      </div>
+      <RightFiltersDrawer onChange={setFilters} />
+    </div>
+  );
+}

--- a/frontend/src/components/history/ExecutionTimeline.test.tsx
+++ b/frontend/src/components/history/ExecutionTimeline.test.tsx
@@ -1,0 +1,31 @@
+import { render, fireEvent, screen } from '@testing-library/react';
+import { ExecutionTimeline } from './ExecutionTimeline';
+import type { Step } from '@/types/history';
+
+describe('ExecutionTimeline', () => {
+  const steps: Step[] = [
+    {
+      id: '1',
+      t: new Date().toISOString(),
+      kind: 'LLM',
+      title: 'call',
+      status: 'failed',
+      details: {
+        error: { code: '429', message: 'Too many requests', hint: 'wait', docUrl: 'https://docs' },
+      },
+    },
+  ];
+
+  it('shows error details when expanded', () => {
+    render(<ExecutionTimeline steps={steps} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText('Too many requests')).toBeInTheDocument();
+    expect(screen.getByText(/Hint: wait/)).toBeInTheDocument();
+  });
+
+  it('filters steps', () => {
+    const filter = (s: Step) => s.status === 'completed';
+    const { queryByText } = render(<ExecutionTimeline steps={steps} filter={filter} />);
+    expect(queryByText('call')).toBeNull();
+  });
+});

--- a/frontend/src/components/history/ExecutionTimeline.tsx
+++ b/frontend/src/components/history/ExecutionTimeline.tsx
@@ -1,0 +1,105 @@
+import { Badge } from '@/components/ui/badge';
+import { ChevronDown, ChevronRight, ExternalLink } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+import type { Step, ErrorInfo } from '@/types/history';
+import { formatTime, ms } from '@/lib/history-utils';
+
+const statusToVariant: Record<Step['status'], 'default' | 'secondary' | 'destructive' | 'outline'> = {
+  completed: 'default',
+  running: 'secondary',
+  failed: 'destructive',
+  timeout: 'destructive',
+  queued: 'outline',
+};
+
+function ErrorBox({ e }: { e: ErrorInfo }) {
+  return (
+    <div className="mt-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm">
+      <div className="font-medium text-red-700">Error{e.code ? `: ${e.code}` : ''}</div>
+      <div className="text-red-800">{e.message}</div>
+      {e.hint && <div className="mt-1 text-red-900/90">Hint: {e.hint}</div>}
+      {e.docUrl && (
+        <a className="mt-2 inline-flex items-center gap-1 text-red-700 underline" href={e.docUrl} target="_blank" rel="noreferrer">
+          Provider docs <ExternalLink className="h-3 w-3" />
+        </a>
+      )}
+    </div>
+  );
+}
+
+export function ExecutionTimeline({ steps, filter }: { steps: Step[]; filter?: (s: Step) => boolean }) {
+  const [open, setOpen] = useState<Record<string, boolean>>({});
+  const toggle = useCallback((id: string) => setOpen((o) => ({ ...o, [id]: !o[id] })), []);
+  const list = filter ? steps.filter(filter) : steps;
+  const onKey = useCallback(
+    (e: React.KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'r') {
+        const last = list[list.length - 1];
+        if (last) toggle(last.id);
+        e.preventDefault();
+      }
+    },
+    [list, toggle]
+  );
+
+  const rows = useMemo(
+    () =>
+      list.map((s) => {
+        const variant = statusToVariant[s.status];
+        return (
+          <div key={s.id} className="group">
+            <div className="grid grid-cols-[auto_1fr_auto] items-center gap-2 py-2">
+              <button onClick={() => toggle(s.id)} className="mr-1 inline-flex items-center text-muted-foreground">
+                {open[s.id] ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+              </button>
+              <div className="flex items-center gap-2">
+                <span className="tabular-nums text-xs text-muted-foreground">{formatTime(s.t)}</span>
+                <Badge variant={variant}>{s.status}</Badge>
+                <span className="text-xs uppercase tracking-wide text-muted-foreground">{s.kind}</span>
+                <span className="font-medium">{s.title}</span>
+              </div>
+              <div className="text-xs text-muted-foreground">{ms(s.latencyMs)}</div>
+            </div>
+            {open[s.id] && (
+              <div className="ml-6 rounded-lg border bg-muted/30 p-3 text-sm" onKeyDown={onKey}>
+                {s.summary && <div className="mb-2">{s.summary}</div>}
+                {s.details?.error ? (
+                  <ErrorBox e={s.details.error} />
+                ) : (
+                  <div className="grid gap-2 md:grid-cols-2">
+                    {s.details?.input && (
+                      <div>
+                        <div className="mb-1 text-xs font-semibold">Input</div>
+                        <pre className="max-h-64 overflow-auto rounded bg-background p-2 text-xs">
+                          {JSON.stringify(s.details.input, null, 2)}
+                        </pre>
+                      </div>
+                    )}
+                    {s.details?.output && (
+                      <div>
+                        <div className="mb-1 text-xs font-semibold">Output</div>
+                        <pre className="max-h-64 overflow-auto rounded bg-background p-2 text-xs">
+                          {JSON.stringify(s.details.output, null, 2)}
+                        </pre>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+            <div className="border-b" />
+          </div>
+        );
+      }),
+    [list, open, toggle, onKey]
+  );
+
+  return (
+    <div className="rounded-2xl border bg-white p-4 shadow-sm" onKeyDown={onKey} tabIndex={0}>
+      <div className="mb-2 text-sm font-semibold">Execution Timeline</div>
+      <div className="max-h-[50vh] min-h-[20vh] overflow-y-auto">
+        {rows.length ? rows : <div className="text-sm text-muted-foreground">No steps</div>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/history/FinalAnswerCard.tsx
+++ b/frontend/src/components/history/FinalAnswerCard.tsx
@@ -1,0 +1,72 @@
+import { useMemo } from 'react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
+import { Copy, Database, Download } from 'lucide-react';
+import type { HistoryRun } from '@/types/history';
+import { ms } from '@/lib/history-utils';
+
+function Markdown({ text }: { text: string }) {
+  return <pre className="whitespace-pre-wrap break-words text-sm">{text}</pre>;
+}
+
+export function FinalAnswerCard({ run }: { run: HistoryRun }) {
+  if (!run.finalAnswer) {
+    return (
+      <div className="rounded-2xl border bg-white p-4 shadow-sm">
+        <div className="text-sm font-semibold">Final Answer</div>
+        <div className="mt-2 text-sm text-destructive">Run did not complete successfully.</div>
+      </div>
+    );
+  }
+
+  const { markdown, json, html } = run.finalAnswer;
+  const meta = useMemo(() => {
+    const parts = [] as string[];
+    if (run.modelMeta) parts.push(`${run.modelMeta.provider}/${run.modelMeta.model}`);
+    if (run.modelMeta?.tokens != null) parts.push(`${run.modelMeta.tokens} tokens`);
+    if (run.stats?.durationMs != null) parts.push(ms(run.stats.durationMs));
+    return parts.join(' • ');
+  }, [run]);
+
+  return (
+    <div className="rounded-2xl border bg-white p-4 shadow-sm">
+      <div className="mb-2 flex items-center justify-between">
+        <div className="text-sm font-semibold">Final Answer</div>
+        <div className="flex gap-2">
+          <Button size="sm" variant="secondary" onClick={() => navigator.clipboard.writeText(markdown ?? '')}>
+            <Copy className="h-4 w-4" />
+          </Button>
+          <Button size="sm" variant="secondary">
+            <Download className="h-4 w-4" />
+          </Button>
+          <Button size="sm" variant="secondary">
+            <Database className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+      <Tabs defaultValue={markdown ? 'md' : json ? 'json' : 'html'} className="mt-2">
+        <TabsList className="grid w-full grid-cols-3">
+          <TabsTrigger value="md">Markdown</TabsTrigger>
+          <TabsTrigger value="json">JSON</TabsTrigger>
+          <TabsTrigger value="html">HTML</TabsTrigger>
+        </TabsList>
+        <TabsContent value="md">{markdown ? <Markdown text={markdown} /> : <div className="text-sm text-muted-foreground">No markdown</div>}</TabsContent>
+        <TabsContent value="json">
+          {json ? (
+            <pre className="whitespace-pre-wrap break-words text-sm">{JSON.stringify(json, null, 2)}</pre>
+          ) : (
+            <div className="text-sm text-muted-foreground">No JSON</div>
+          )}
+        </TabsContent>
+        <TabsContent value="html">
+          {html ? (
+            <div dangerouslySetInnerHTML={{ __html: html }} />
+          ) : (
+            <div className="text-sm text-muted-foreground">No HTML</div>
+          )}
+        </TabsContent>
+      </Tabs>
+      {meta && <div className="mt-2 text-xs text-muted-foreground">{meta}</div>}
+    </div>
+  );
+}

--- a/frontend/src/components/history/RightFiltersDrawer.tsx
+++ b/frontend/src/components/history/RightFiltersDrawer.tsx
@@ -1,0 +1,81 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useState } from 'react';
+import type { Step } from '@/types/history';
+
+export type Filters = {
+  status: 'all' | Step['status'];
+  kind: 'all' | Step['kind'];
+  time: '15m' | '1h' | '24h';
+  group: 'run' | 'tool';
+};
+
+export function RightFiltersDrawer({ onChange }: { onChange: (f: Filters) => void }) {
+  const [filters, setFilters] = useState<Filters>({ status: 'all', kind: 'all', time: '1h', group: 'run' });
+  function update<K extends keyof Filters>(k: K, v: Filters[K]) {
+    const next = { ...filters, [k]: v };
+    setFilters(next);
+    onChange(next);
+  }
+  return (
+    <aside className="hidden w-60 flex-shrink-0 md:block">
+      <div className="rounded-2xl border bg-white p-4 shadow-sm">
+        <div className="mb-4 text-sm font-semibold">Filters</div>
+        <div className="mb-3 text-sm">
+          <div className="mb-1">Status</div>
+          <Select value={filters.status} onValueChange={(v) => update('status', v as Filters['status'])}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All</SelectItem>
+              <SelectItem value="completed">Completed</SelectItem>
+              <SelectItem value="failed">Failed</SelectItem>
+              <SelectItem value="timeout">Timeout</SelectItem>
+              <SelectItem value="running">Running</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="mb-3 text-sm">
+          <div className="mb-1">Kind</div>
+          <Select value={filters.kind} onValueChange={(v) => update('kind', v as Filters['kind'])}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All</SelectItem>
+              <SelectItem value="LLM">LLM</SelectItem>
+              <SelectItem value="Tool">Tool</SelectItem>
+              <SelectItem value="DB">DB</SelectItem>
+              <SelectItem value="System">System</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="mb-3 text-sm">
+          <div className="mb-1">Time</div>
+          <Select value={filters.time} onValueChange={(v) => update('time', v as Filters['time'])}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="15m">Last 15m</SelectItem>
+              <SelectItem value="1h">Last 1h</SelectItem>
+              <SelectItem value="24h">Last 24h</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="text-sm">
+          <div className="mb-1">Group by</div>
+          <Select value={filters.group} onValueChange={(v) => update('group', v as Filters['group'])}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="run">Run</SelectItem>
+              <SelectItem value="tool">Tool</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/components/history/UserPromptCard.tsx
+++ b/frontend/src/components/history/UserPromptCard.tsx
@@ -1,0 +1,38 @@
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Copy, MoreHorizontal, RefreshCw } from 'lucide-react';
+import { formatTime } from '@/lib/history-utils';
+
+export function UserPromptCard({ prompt, time }: { prompt: string; time: string }) {
+  return (
+    <div className="rounded-2xl border bg-white p-4 shadow-sm">
+      <div className="flex items-center justify-between text-sm text-muted-foreground">
+        <span>{formatTime(time)}</span>
+        <div className="flex items-center gap-2">
+          <Button size="sm" variant="secondary" aria-label="Replay">
+            <RefreshCw className="h-4 w-4" />
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button size="sm" variant="ghost" aria-label="More actions">
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => navigator.clipboard.writeText(prompt)}>
+                <Copy className="mr-2 h-4 w-4" /> Copy
+              </DropdownMenuItem>
+              <DropdownMenuItem>Duplicate draft</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+      <pre className="mt-2 whitespace-pre-wrap break-words text-sm">{prompt}</pre>
+    </div>
+  );
+}

--- a/frontend/src/lib/history-utils.test.ts
+++ b/frontend/src/lib/history-utils.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { formatTime, ms } from './history-utils';
+
+// Given/When/Then style comments
+
+describe('ms', () => {
+  it('formats numbers', () => {
+    expect(ms(123)).toBe('123ms');
+  });
+  it('handles undefined', () => {
+    expect(ms()).toBe('');
+  });
+});
+
+describe('formatTime', () => {
+  it('formats ISO strings', () => {
+    const date = new Date('2024-01-01T12:34:56Z');
+    expect(formatTime(date.toISOString())).toMatch(/12:34/);
+  });
+  it('handles invalid strings', () => {
+    expect(formatTime('invalid')).toBe('Invalid Date');
+  });
+});

--- a/frontend/src/lib/history-utils.ts
+++ b/frontend/src/lib/history-utils.ts
@@ -1,0 +1,8 @@
+export function ms(n?: number): string {
+  return n == null ? '' : `${n}ms`;
+}
+
+export function formatTime(t: string): string {
+  const d = new Date(t);
+  return d.toLocaleTimeString();
+}

--- a/frontend/src/types/history-demo.ts
+++ b/frontend/src/types/history-demo.ts
@@ -1,0 +1,60 @@
+import { HistoryRun } from './history';
+
+const now = Date.now();
+export const demoRun: HistoryRun = {
+  id: 'demo',
+  startedAt: new Date(now).toISOString(),
+  userPrompt: 'Find the item and list related entries.',
+  agentPlan: {
+    bullets: ['Use find_item tool', 'Then list_items for context'],
+    rationale: 'First locate the item then show related entries.',
+  },
+  steps: [
+    {
+      id: 's1',
+      t: new Date(now + 100).toISOString(),
+      kind: 'Tool',
+      title: 'find_item',
+      status: 'completed',
+      latencyMs: 1600,
+      details: { input: { id: 1 }, output: { item: { id: 1, name: 'Widget' } } },
+    },
+    {
+      id: 's2',
+      t: new Date(now + 2000).toISOString(),
+      kind: 'Tool',
+      title: 'list_items',
+      status: 'completed',
+      latencyMs: 474,
+      details: { input: { parent: 1 }, output: { items: [1, 2, 3] } },
+    },
+    {
+      id: 's3',
+      t: new Date(now + 2600).toISOString(),
+      kind: 'LLM',
+      title: 'summarize',
+      status: 'failed',
+      latencyMs: 200,
+      details: {
+        error: {
+          code: '429',
+          message: 'Rate limit exceeded',
+          hint: 'Reduce request rate',
+          docUrl: 'https://example.com/429',
+        },
+      },
+    },
+    {
+      id: 's4',
+      t: new Date(now + 3000).toISOString(),
+      kind: 'LLM',
+      title: 'final answer',
+      status: 'timeout',
+      latencyMs: 30000,
+      details: {
+        error: { message: 'Request timed out', hint: 'Try again with a smaller prompt' },
+      },
+    },
+  ],
+  stats: { durationMs: 3200, toolCount: 2, errorCount: 2 },
+};

--- a/frontend/src/types/history.ts
+++ b/frontend/src/types/history.ts
@@ -1,0 +1,22 @@
+export type ErrorInfo = { code?: string; message: string; hint?: string; docUrl?: string };
+export type Step = {
+  id: string;
+  t: string;
+  kind: 'LLM' | 'Tool' | 'DB' | 'System';
+  title: string;
+  status: 'queued' | 'running' | 'completed' | 'failed' | 'timeout';
+  latencyMs?: number;
+  summary?: string;
+  details?: { input?: any; output?: any; error?: ErrorInfo };
+};
+export type HistoryRun = {
+  id: string;
+  startedAt: string;
+  endedAt?: string;
+  userPrompt: string;
+  agentPlan: { bullets: string[]; rationale?: string };
+  steps: Step[];
+  finalAnswer?: { markdown?: string; json?: any; html?: string };
+  modelMeta?: { provider: 'openai' | 'anthropic' | 'mistral'; model: string; tokens?: number };
+  stats?: { durationMs?: number; toolCount: number; errorCount: number };
+};


### PR DESCRIPTION
## Summary
- add history domain types and demo data
- implement composable history cards for prompts, plan, timeline, final answers, and filters
- provide utilities with tests

## Testing
- `cd frontend && pnpm test --run src/lib/history-utils.test.ts src/components/history/ExecutionTimeline.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b6e600c26c8330b043fb5b8d5b897c