### PR TITLE
feat: add JSON logging handler

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -35,9 +35,10 @@ from orchestrator.models import (
 )
 import httpx
 from agents.embeddings import chunk_text, embed_texts
+from orchestrator.logging_utils import JSONLHandler
 
 
-def setup_logging() -> None:
+def setup_logging(log_dir: str = "logs") -> None:
     level_name = os.getenv("LOGLEVEL", "INFO").upper()
     level = getattr(logging, level_name, logging.INFO)
 
@@ -51,6 +52,9 @@ def setup_logging() -> None:
             logging.Formatter("%(asctime)s | %(levelname)s | %(name)s | %(message)s")
         )
         root.addHandler(h)
+
+    if not any(isinstance(h, JSONLHandler) for h in root.handlers):
+        root.addHandler(JSONLHandler(log_dir))
 
 
 async def _no_aclose(self):

--- a/orchestrator/logging_utils.py
+++ b/orchestrator/logging_utils.py
@@ -1,0 +1,74 @@
+import os
+import json
+import logging
+from datetime import datetime
+from typing import Any, Optional
+
+
+class JSONLHandler(logging.Handler):
+    """Write logs as JSON lines with daily rotation."""
+
+    def __init__(self, directory: str = "logs") -> None:
+        super().__init__()
+        self.directory = directory
+        os.makedirs(directory, exist_ok=True)
+        self._current_date: Optional[str] = None
+        self._stream: Optional[Any] = None
+
+    def _update_stream(self) -> None:
+        date = datetime.utcnow().strftime("%Y%m%d")
+        if self._current_date != date:
+            if self._stream:
+                self._stream.close()
+            self._current_date = date
+            path = os.path.join(self.directory, f"app-{date}.jsonl")
+            self._stream = open(path, "a", encoding="utf-8")
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - used in tests
+        try:
+            self.acquire()
+            self._update_stream()
+            payload = {
+                "ts": datetime.utcnow().isoformat(),
+                "level": record.levelname,
+                "logger": record.name,
+                "message": record.getMessage(),
+                "area": getattr(record, "area", None),
+                "run_id": getattr(record, "run_id", None),
+                "agent": getattr(record, "agent", None),
+                "tool": getattr(record, "tool", None),
+                "payload": getattr(record, "payload", None),
+            }
+            assert self._stream is not None  # for type checkers
+            json.dump(payload, self._stream, default=str)
+            self._stream.write("\n")
+            self._stream.flush()
+        except Exception:
+            self.handleError(record)
+        finally:
+            self.release()
+
+    def close(self) -> None:
+        try:
+            if self._stream:
+                self._stream.close()
+        finally:
+            super().close()
+
+
+def log_extra(
+    *,
+    area: str | None = None,
+    run_id: str | None = None,
+    agent: str | None = None,
+    tool: str | None = None,
+    payload: Any | None = None,
+) -> dict[str, Any]:
+    """Return an extra dict for structured logging."""
+    return {
+        "area": area,
+        "run_id": run_id,
+        "agent": agent,
+        "tool": tool,
+        "payload": payload,
+    }


### PR DESCRIPTION
## Summary
- add JSONL logging handler with daily rotation
- provide `log_extra` helper for structured context
- test log handler and update existing logging tests

## Testing
- `pytest tests/test_logging.py -q`
- `pytest -q` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c6a14ce88330897471d51a4be13a