### PR TITLE
feat: add timeline and cost endpoints

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -26,6 +26,8 @@ from orchestrator.models import (
     DocumentOut,
     RunDetail,
     RunSummary,
+    TimelineEvent,
+    RunCost,
     FeatureCreate,
     EpicCreate,
     CapabilityCreate,
@@ -174,6 +176,26 @@ async def get_run_steps(run_id: str, limit: int = Query(200, ge=1, le=1000)):
         raise HTTPException(status_code=404, detail="Run not found")
     steps = crud.get_run_steps(run_id, limit)
     return {"run_id": run_id, "steps": steps, "total_steps": len(steps)}
+
+
+@app.get("/runs/{run_id}/timeline", response_model=list[TimelineEvent])
+async def get_run_timeline(
+    run_id: str,
+    limit: int = Query(1000, ge=1, le=1000),
+    cursor: str | None = None,
+):
+    run = crud.get_run(run_id)
+    if not run:
+        raise HTTPException(status_code=404, detail="Run not found")
+    return crud.get_run_timeline(run_id, limit=limit, cursor=cursor)
+
+
+@app.get("/runs/{run_id}/cost", response_model=RunCost)
+async def get_run_cost(run_id: str):
+    run = crud.get_run(run_id)
+    if not run:
+        raise HTTPException(status_code=404, detail="Run not found")
+    return crud.get_run_cost(run_id)
 
 
 @app.get("/runs", response_model=list[RunSummary])

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -1,7 +1,7 @@
 # orchestrator/models.py
 from pydantic import BaseModel, Field
 from datetime import datetime
-from typing import Literal, Union
+from typing import Any, Literal, Union
 
 class Project(BaseModel):
     id: int
@@ -80,6 +80,34 @@ class RunSummary(BaseModel):
     status: Literal["running", "done"]
     created_at: datetime
     completed_at: datetime | None = None
+
+
+# Unified timeline event model
+class TimelineEvent(BaseModel):
+    type: Literal[
+        "agent.span.start",
+        "agent.span.end",
+        "message",
+        "tool.call",
+        "tool.result",
+    ]
+    ts: datetime
+    run_id: str
+    agent: str | None = None
+    label: str
+    ref: dict[str, Any] = Field(default_factory=dict)
+    meta: dict[str, Any] = Field(default_factory=dict)
+
+
+class AgentCost(BaseModel):
+    agent: str | None
+    tokens: int = 0
+    cost_eur: float = 0.0
+
+
+class RunCost(BaseModel):
+    by_agent: list[AgentCost]
+    total: AgentCost
 
 
 # Backward compatibility for existing imports

--- a/tests/test_timeline_cost.py
+++ b/tests/test_timeline_cost.py
@@ -1,0 +1,156 @@
+import json
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from api.main import app
+from orchestrator import crud
+
+
+@pytest.fixture(autouse=True)
+def setup_db(monkeypatch, tmp_path):
+    db = tmp_path / "db.sqlite"
+    monkeypatch.setattr(crud, "DATABASE_URL", str(db))
+    crud.init_db()
+    yield
+
+
+@pytest.mark.asyncio
+async def test_timeline_events_order_and_limit():
+    run_id = "r1"
+    crud.create_run(run_id, "obj", 1)
+    conn = crud.get_conn()
+    conn.execute(
+        "INSERT INTO agent_spans(run_id, agent_name, label, start_ts, end_ts, ref, meta) VALUES (?,?,?,?,?,?,?)",
+        (
+            run_id,
+            "planner",
+            "plan",
+            "2024-01-01T00:00:00",
+            "2024-01-01T00:00:10",
+            json.dumps({"r": 1}),
+            json.dumps({"m": 1}),
+        ),
+    )
+    conn.execute(
+        "INSERT INTO messages(run_id, agent_name, label, ts, ref, meta, token_count, cost_eur) VALUES (?,?,?,?,?,?,?,?)",
+        (
+            run_id,
+            "planner",
+            "msg",
+            "2024-01-01T00:00:01",
+            "{}",
+            "{}",
+            10,
+            0.1,
+        ),
+    )
+    conn.execute(
+        "INSERT INTO tool_calls(run_id, agent_name, label, ts, ref, meta) VALUES (?,?,?,?,?,?)",
+        (
+            run_id,
+            "planner",
+            "tool",
+            "2024-01-01T00:00:02",
+            "{}",
+            "{}",
+        ),
+    )
+    conn.execute(
+        "INSERT INTO tool_results(run_id, agent_name, label, ts, ref, meta) VALUES (?,?,?,?,?,?)",
+        (
+            run_id,
+            "planner",
+            "tool",
+            "2024-01-01T00:00:03",
+            "{}",
+            "{}",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        resp = await ac.get(f"/runs/{run_id}/timeline")
+    assert resp.status_code == 200
+    events = resp.json()
+    types = [e["type"] for e in events]
+    assert types == [
+        "agent.span.start",
+        "message",
+        "tool.call",
+        "tool.result",
+        "agent.span.end",
+    ]
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        resp2 = await ac.get(f"/runs/{run_id}/timeline", params={"limit": 2})
+    assert len(resp2.json()) == 2
+
+
+@pytest.mark.asyncio
+async def test_timeline_run_not_found():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        resp = await ac.get("/runs/missing/timeline")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_cost_aggregation_and_edges():
+    run_id = "r2"
+    crud.create_run(run_id, "obj", 1)
+    conn = crud.get_conn()
+    conn.executemany(
+        "INSERT INTO messages(run_id, agent_name, label, ts, ref, meta, token_count, cost_eur) VALUES (?,?,?,?,?,?,?,?)",
+        [
+            (
+                run_id,
+                "planner",
+                "m1",
+                "2024-01-01T00:00:00",
+                "{}",
+                "{}",
+                10,
+                0.1,
+            ),
+            (
+                run_id,
+                "writer",
+                "m2",
+                "2024-01-01T00:00:01",
+                "{}",
+                "{}",
+                5,
+                0.05,
+            ),
+            (
+                run_id,
+                "planner",
+                "m3",
+                "2024-01-01T00:00:02",
+                "{}",
+                "{}",
+                3,
+                0.02,
+            ),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        resp = await ac.get(f"/runs/{run_id}/cost")
+    data = resp.json()
+    assert resp.status_code == 200
+    assert data["total"]["tokens"] == 18
+    assert pytest.approx(data["total"]["cost_eur"], 0.001) == 0.17
+    by_agent = {d["agent"]: d for d in data["by_agent"]}
+    assert by_agent["planner"]["tokens"] == 13
+    assert by_agent["writer"]["cost_eur"] == 0.05
+
+    run_id_empty = "r3"
+    crud.create_run(run_id_empty, "obj", 1)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        empty_resp = await ac.get(f"/runs/{run_id_empty}/cost")
+        missing_resp = await ac.get("/runs/missing/cost")
+    assert empty_resp.json()["total"]["tokens"] == 0
+    assert missing_resp.status_code == 404


### PR DESCRIPTION
## Summary
- expose unified timeline stream for runs including spans, messages, and tool interactions
- add cost aggregation endpoint by agent
- cover new endpoints with tests

## Testing
- `pytest tests/test_timeline_cost.py`
- `pytest` *(fails: OpenAIEmbeddings object requires api_key, ChatOpenAI missing model attr, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b7cd44d5f08330bedb4f1774395f87