### PR TITLE
feat: add run timeline viewer

### DIFF
--- a/frontend/src/app/runs/RunDetail.test.tsx
+++ b/frontend/src/app/runs/RunDetail.test.tsx
@@ -25,17 +25,26 @@ afterEach(() => {
 });
 
 it('shows run details when run exists', async () => {
-  global.fetch = vi.fn().mockResolvedValue({
-    ok: true,
-    status: 200,
-    json: async () => ({
-      run_id: '1',
-      objective: 'test',
-      status: 'running',
-      created_at: new Date().toISOString(),
-      steps: [],
-    }),
-  });
+  global.fetch = vi
+    .fn()
+    .mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        run_id: '1',
+        objective: 'test',
+        status: 'running',
+        created_at: new Date().toISOString(),
+      }),
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ events: [] }),
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ tokens: 0, cost: 0, by_agent: {} }),
+    });
   render(<RunDetail params={{ run_id: '1' }} />);
   expect(await screen.findByText('Run 1')).toBeInTheDocument();
 });

--- a/frontend/src/app/runs/[run_id]/page.tsx
+++ b/frontend/src/app/runs/[run_id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import RunTimeline, { TimelineStep } from "@/components/RunTimeline";
+import RunTimeline from "@/components/RunTimeline";
 import { http } from "@/lib/api";
 import { connectWS } from "@/lib/ws";
 
@@ -13,7 +13,6 @@ interface Run {
   completed_at?: string | null;
   html?: string | null;
   summary?: string | null;
-  steps: TimelineStep[];
 }
 
 export default function RunDetail({ params }: { params: { run_id: string } }) {
@@ -62,15 +61,6 @@ export default function RunDetail({ params }: { params: { run_id: string } }) {
             completed_at: msg.completed_at ?? prev.completed_at,
           };
         }
-        if (msg.node) {
-          const step: TimelineStep = {
-            order: msg.order ?? prev.steps.length + 1,
-            node: msg.node,
-            timestamp: msg.timestamp ?? new Date().toISOString(),
-            content: msg.content ?? "",
-          };
-          return { ...prev, steps: [...prev.steps, step] };
-        }
         return prev;
       });
     };
@@ -108,7 +98,7 @@ export default function RunDetail({ params }: { params: { run_id: string } }) {
           </p>
         )}
       </div>
-      <RunTimeline steps={run.steps} />
+      <RunTimeline runId={run.run_id} />
       {run.status === "done" && (
         <div className="space-y-4">
           {run.summary && <p>{run.summary}</p>}

--- a/frontend/src/components/RunTimeline.test.tsx
+++ b/frontend/src/components/RunTimeline.test.tsx
@@ -1,27 +1,73 @@
-import { render, screen, fireEvent, within } from "@testing-library/react";
-import RunTimeline, { TimelineStep } from "./RunTimeline";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { vi } from "vitest";
+import RunTimeline from "./RunTimeline";
 
-describe("RunTimeline detail", () => {
-  const steps: TimelineStep[] = [
-    { order: 1, node: "plan", timestamp: "2024-01-01T00:00:00Z", content: "plan step" },
-    { order: 2, node: "execute", timestamp: "2024-01-01T00:01:00Z", content: "execute step" },
-  ];
-
-  it("renders provided steps", () => {
-    render(<RunTimeline steps={steps} />);
-    expect(screen.getByText("plan")).toBeInTheDocument();
-    expect(screen.getByText("execute")).toBeInTheDocument();
+describe("RunTimeline", () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = "http://api.test";
   });
 
-  it("shows fallback when no steps", () => {
-    render(<RunTimeline steps={[]} />);
-    expect(screen.getByText(/No steps yet/i)).toBeInTheDocument();
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
-  it("opens modal with step details on click", () => {
-    render(<RunTimeline steps={steps} />);
-    fireEvent.click(screen.getByText("plan"));
-    const dialog = screen.getByRole("dialog");
-    expect(within(dialog).getByText("plan step")).toBeInTheDocument();
+  it("renders timeline and cost", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          events: [
+            { type: "agent.span.start", timestamp: "2024-01-01", name: "alpha" },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          tokens: 5,
+          cost: 0.1,
+          by_agent: { alpha: { tokens: 5, cost: 0.1 } },
+        }),
+      });
+
+    render(<RunTimeline runId="1" />);
+    expect(await screen.findByText(/Agent alpha/)).toBeInTheDocument();
+    expect(screen.getByText(/Tokens: 5/)).toBeInTheDocument();
+  });
+
+  it("handles fetch error", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) });
+    render(<RunTimeline runId="1" />);
+    expect(await screen.findByText(/Failed to load timeline/)).toBeInTheDocument();
+  });
+
+  it("opens modal with message content", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          events: [
+            {
+              type: "message",
+              timestamp: "2024-01-01",
+              role: "user",
+              content: "hello",
+              ref: "blob1",
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tokens: 0, cost: 0, by_agent: {} }),
+      })
+      .mockResolvedValueOnce({ ok: true, text: async () => "full" });
+
+    render(<RunTimeline runId="1" />);
+    const view = await screen.findByText("View");
+    fireEvent.click(view);
+    expect(await screen.findByText("full")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/RunTimeline.tsx
+++ b/frontend/src/components/RunTimeline.tsx
@@ -1,55 +1,213 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { http } from "@/lib/api";
+import { Bot, ChevronDown, ChevronUp, User, Wrench } from "lucide-react";
 
-export interface TimelineStep {
-  order: number;
-  node: string;
+interface BaseEvent {
+  id?: string;
+  type: string;
   timestamp: string;
+}
+
+interface AgentStart extends BaseEvent {
+  type: "agent.span.start";
+  name: string;
+}
+
+interface AgentEnd extends BaseEvent {
+  type: "agent.span.end";
+  name: string;
+  duration: number;
+}
+
+interface MessageEvent extends BaseEvent {
+  type: "message";
+  role: string;
   content: string;
+  ref?: string;
 }
 
-interface TimelineProps {
-  steps: TimelineStep[];
+interface ToolCall extends BaseEvent {
+  type: "tool.call";
+  name: string;
 }
 
-export default function RunTimeline({ steps }: TimelineProps) {
-  const [selected, setSelected] = useState<TimelineStep | null>(null);
-  return (
-    <div>
-      <ul className="divide-y rounded border">
-        {steps.map((s) => (
-          <li
-            key={s.order}
-            className="p-2 cursor-pointer hover:bg-muted/50"
-            onClick={() => setSelected(s)}
-          >
-            <div className="flex items-center gap-2">
-              <span className="font-mono text-xs w-6">{s.order}</span>
-              <span className="text-sm font-medium flex-1">{s.node}</span>
-              <span className="text-xs text-muted-foreground">
-                {new Date(s.timestamp).toLocaleTimeString()}
-              </span>
+interface ToolResult extends BaseEvent {
+  type: "tool.result";
+  name: string;
+}
+
+export type TimelineEvent =
+  | AgentStart
+  | AgentEnd
+  | MessageEvent
+  | ToolCall
+  | ToolResult;
+
+interface CostInfo {
+  tokens: number;
+  cost: number;
+  by_agent: Record<string, { tokens: number; cost: number }>;
+}
+
+export default function RunTimeline({ runId }: { runId: string }) {
+  const [events, setEvents] = useState<TimelineEvent[]>([]);
+  const [cost, setCost] = useState<CostInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showCost, setShowCost] = useState(false);
+  const [modal, setModal] = useState<{ title: string; content: string } | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        setLoading(true);
+        const [tRes, cRes] = await Promise.all([
+          http(`/runs/${runId}/timeline`),
+          http(`/runs/${runId}/cost`),
+        ]);
+        if (!tRes.ok || !cRes.ok) throw new Error("fetch failed");
+        const tData = await tRes.json();
+        const cData = await cRes.json();
+        if (!cancelled) {
+          setEvents(tData.events || []);
+          setCost(cData);
+          setError(null);
+        }
+      } catch (e) {
+        if (!cancelled) setError("Failed to load timeline");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [runId]);
+
+  function roleIcon(role: string) {
+    switch (role) {
+      case "user":
+        return <User className="mt-1 size-4" />;
+      default:
+        return <Bot className="mt-1 size-4" />;
+    }
+  }
+
+  async function openMessage(evt: MessageEvent) {
+    try {
+      if (evt.ref) {
+        const res = await http(`/blobs/${evt.ref}`);
+        const text = res.ok ? await res.text() : "Failed to load content";
+        setModal({ title: `${evt.role} message`, content: text });
+      } else {
+        setModal({ title: `${evt.role} message`, content: evt.content });
+      }
+    } catch {
+      setModal({ title: `${evt.role} message`, content: "Failed to load content" });
+    }
+  }
+
+  function renderEvent(evt: TimelineEvent, idx: number) {
+    switch (evt.type) {
+      case "agent.span.start":
+        return (
+          <Badge variant="secondary">▶ Agent {evt.name}</Badge>
+        );
+      case "agent.span.end":
+        return (
+          <Badge variant="outline">■ Agent {evt.name} ({evt.duration.toFixed(2)}s)</Badge>
+        );
+      case "message":
+        return (
+          <div className="flex items-start gap-2">
+            {roleIcon(evt.role)}
+            <div className="flex-1 truncate rounded bg-muted p-2 text-sm">
+              {evt.content}
             </div>
-            <p className="text-xs text-muted-foreground truncate">
-              {s.content}
-            </p>
+            <Button
+              variant="link"
+              className="h-auto p-0"
+              onClick={() => openMessage(evt)}
+            >
+              View
+            </Button>
+          </div>
+        );
+      case "tool.call":
+        return (
+          <div className="ml-4 flex items-center gap-1 text-xs text-muted-foreground">
+            <Wrench className="size-3" /> call {evt.name}
+          </div>
+        );
+      case "tool.result":
+        return (
+          <div className="ml-4 flex items-center gap-1 text-xs text-muted-foreground">
+            <Wrench className="size-3" /> result {evt.name}
+          </div>
+        );
+      default:
+        return null;
+    }
+  }
+
+  if (loading) return <div>Loading timeline...</div>;
+  if (error) return <div className="text-destructive">{error}</div>;
+
+  return (
+    <div className="relative">
+      {cost && (
+        <div className="absolute right-0 -top-2">
+          <Badge
+            className="cursor-pointer"
+            onClick={() => setShowCost((c) => !c)}
+          >
+            Tokens: {cost.tokens} | Cost: €{cost.cost.toFixed(2)}
+            {showCost ? (
+              <ChevronUp className="ml-1 size-3" />
+            ) : (
+              <ChevronDown className="ml-1 size-3" />
+            )}
+          </Badge>
+          {showCost && (
+            <div className="mt-2 rounded border bg-background p-2">
+              <table className="text-xs">
+                <tbody>
+                  {Object.entries(cost.by_agent || {}).map(([agent, info]) => (
+                    <tr key={agent}>
+                      <td className="pr-2">{agent}</td>
+                      <td className="pr-2 text-right">{info.tokens}</td>
+                      <td className="text-right">€{info.cost.toFixed(2)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+      <ul className="space-y-4 border-l pl-4">
+        {events.map((evt, idx) => (
+          <li key={evt.id || idx} className="relative">
+            <span className="absolute -left-2 top-1 size-2 rounded-full bg-primary" />
+            {renderEvent(evt, idx)}
           </li>
         ))}
-        {steps.length === 0 && (
-          <li className="p-2 text-sm text-muted-foreground">No steps yet</li>
+        {events.length === 0 && (
+          <li className="text-sm text-muted-foreground">No events</li>
         )}
       </ul>
-      <Dialog open={!!selected} onOpenChange={(o) => !o && setSelected(null)}>
+      <Dialog open={!!modal} onOpenChange={(o) => !o && setModal(null)}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>
-              Step {selected?.order}: {selected?.node}
-            </DialogTitle>
+            <DialogTitle>{modal?.title}</DialogTitle>
           </DialogHeader>
-          <div className="mt-2 whitespace-pre-wrap text-sm">
-            {selected?.content}
-          </div>
+          <div className="whitespace-pre-wrap text-sm">{modal?.content}</div>
         </DialogContent>
       </Dialog>
     </div>


### PR DESCRIPTION
## Summary
- display run timeline with agent spans, messages, and tool calls
- fetch and show per-agent token costs
- add tests for timeline rendering and run detail fetching

## Testing
- `pnpm vitest run src/components/RunTimeline.test.tsx src/app/runs/RunDetail.test.tsx`
- `pytest tests/test_runs.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7d2c6087c8330895e9d7e1427ac83