### PR TITLE
feat: add preflight validator for tool messages

### DIFF
--- a/orchestrator/llm/preflight.py
+++ b/orchestrator/llm/preflight.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+"""Preflight validation for OpenAI chat messages.
+
+Ensures tool messages are only sent when the immediately preceding assistant
+message contains a matching tool_calls entry.
+"""
+
+from typing import List, Dict
+import logging
+import json
+
+logger = logging.getLogger(__name__)
+
+
+def preflight_validate_messages(messages: List[Dict]) -> List[Dict]:
+    """Return a sanitized copy of *messages* with invalid tool messages dropped.
+
+    A tool message is kept only if:
+    * The immediately preceding message is an assistant message with a
+      ``tool_calls`` entry whose ``id`` matches the tool message's
+      ``tool_call_id``.
+    * No other messages appear between the assistant and tool message.
+
+    Offending tool messages are removed and a structured warning is logged.
+    The original list is not mutated.
+    """
+
+    sanitized: List[Dict] = []
+    last_tool_ids: set[str] = set()
+    expecting_tool = False  # True if last kept message was assistant w/ tool calls
+
+    for idx, msg in enumerate(messages):
+        role = msg.get("role")
+        if role == "assistant":
+            sanitized.append(msg.copy())
+            tool_calls = msg.get("tool_calls") or []
+            last_tool_ids = {
+                tc.get("id")
+                for tc in tool_calls
+                if isinstance(tc, dict) and tc.get("id")
+            }
+            expecting_tool = bool(last_tool_ids)
+        elif role == "tool":
+            tool_id = msg.get("tool_call_id")
+            if expecting_tool and tool_id in last_tool_ids:
+                sanitized.append(msg.copy())
+            else:
+                reason = (
+                    "missing parent assistant"
+                    if not expecting_tool
+                    else "unknown tool_call_id"
+                )
+                excerpt = [
+                    {"index": i, "role": messages[i].get("role")}
+                    for i in range(max(0, idx - 2), min(len(messages), idx + 3))
+                ]
+                logger.warning(
+                    json.dumps(
+                        {
+                            "tool_call_id": tool_id,
+                            "reason": reason,
+                            "excerpt": excerpt,
+                        }
+                    )
+                )
+            # Whether kept or dropped, allow further tool messages for the same
+            # assistant so long as there are declared tool IDs.
+            expecting_tool = bool(last_tool_ids)
+        else:
+            sanitized.append(msg.copy())
+            expecting_tool = False
+
+    return sanitized
+
+
+def chat_completions_create(client, messages: List[Dict], **kwargs):
+    """Wrapper around ``client.chat.completions.create`` with message preflight."""
+    clean = preflight_validate_messages(messages)
+    return client.chat.completions.create(messages=clean, **kwargs)

--- a/tests/test_preflight_validator.py
+++ b/tests/test_preflight_validator.py
@@ -1,0 +1,62 @@
+import json
+import logging
+import pytest
+from orchestrator.llm.preflight import preflight_validate_messages
+
+
+@pytest.fixture(autouse=True)
+def patch_graph():
+    """Override global fixture from conftest; not needed here."""
+    yield
+
+
+def test_valid_sequence_unchanged():
+    msgs = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "a1", "type": "function", "function": {"name": "x", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "a1", "content": "{}"},
+    ]
+    out = preflight_validate_messages(msgs)
+    assert out == msgs
+    assert out is not msgs
+
+
+def test_invalid_tool_dropped(caplog):
+    msgs = [
+        {"role": "user", "content": "hi"},
+        {"role": "tool", "tool_call_id": "oops", "content": "{}"},
+    ]
+    with caplog.at_level(logging.WARNING):
+        out = preflight_validate_messages(msgs)
+    assert out == [msgs[0]]
+    rec = caplog.records[0]
+    data = json.loads(rec.message)
+    assert data["tool_call_id"] == "oops"
+    assert data["reason"] == "missing parent assistant"
+    assert data["excerpt"][0] == {"index": 0, "role": "user"}
+
+
+def test_mixed_valid_invalid_tools(caplog):
+    msgs = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "a1", "type": "function", "function": {"name": "x", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "a1", "content": "ok"},
+        {"role": "tool", "tool_call_id": "missing", "content": "bad"},
+    ]
+    with caplog.at_level(logging.WARNING):
+        out = preflight_validate_messages(msgs)
+    assert out == msgs[:2]
+    assert len(caplog.records) == 1
+    data = json.loads(caplog.records[0].message)
+    assert data["tool_call_id"] == "missing"
+    assert data["reason"] == "unknown tool_call_id"


### PR DESCRIPTION
## Summary
- add `preflight_validate_messages` to drop stray tool messages and log structured warnings
- wrap OpenAI `chat.completions.create` with validator
- test validator behavior for valid, invalid and mixed tool message sequences

## Testing
- `pytest tests/test_preflight_validator.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*


------
https://chatgpt.com/codex/tasks/task_e_68b7dcf877248330a3dcccdfff8f3ffd