### PR TITLE
feat: validate and slice tool exchanges

### DIFF
--- a/tests/test_preflight_validator.py
+++ b/tests/test_preflight_validator.py
@@ -1,7 +1,10 @@
 import json
 import logging
 import pytest
-from orchestrator.llm.preflight import preflight_validate_messages
+from orchestrator.llm.preflight import (
+    preflight_validate_messages,
+    extract_tool_exchange_slice,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -36,9 +39,10 @@ def test_invalid_tool_dropped(caplog):
     assert out == [msgs[0]]
     rec = caplog.records[0]
     data = json.loads(rec.message)
+    assert data["event"] == "drop_orphan_tool"
     assert data["tool_call_id"] == "oops"
     assert data["reason"] == "missing parent assistant"
-    assert data["excerpt"][0] == {"index": 0, "role": "user"}
+    assert data["idx"] == 1
 
 
 def test_mixed_valid_invalid_tools(caplog):
@@ -58,5 +62,35 @@ def test_mixed_valid_invalid_tools(caplog):
     assert out == msgs[:2]
     assert len(caplog.records) == 1
     data = json.loads(caplog.records[0].message)
+    assert data["event"] == "drop_orphan_tool"
     assert data["tool_call_id"] == "missing"
     assert data["reason"] == "unknown tool_call_id"
+    assert data["idx"] == 2
+
+
+def test_non_adjacent_tool_slice(caplog):
+    msgs = [
+        {"role": "system", "content": "s"},
+        {"role": "user", "content": "u1"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "a1", "type": "function", "function": {"name": "x", "arguments": "{}"}}
+            ],
+        },
+        {"role": "user", "content": "noise"},
+        {"role": "tool", "tool_call_id": "a1", "content": "{}"},
+    ]
+
+    with caplog.at_level(logging.WARNING):
+        full = preflight_validate_messages(msgs)
+    # tool dropped because it's not adjacent
+    assert full == msgs[:-1]
+    data = json.loads(caplog.records[0].message)
+    assert data["reason"] == "missing parent assistant"
+
+    slice_msgs = extract_tool_exchange_slice(msgs)
+    assert slice_msgs == [msgs[0], msgs[1], msgs[2], msgs[4]]
+    out = preflight_validate_messages(slice_msgs)
+    assert out == slice_msgs


### PR DESCRIPTION
## Summary
- drop orphan tool messages before OpenAI calls
- slice trailing tool exchanges and route to gpt-4o-mini
- tests for message validator and exchange slicing

## Testing
- `pytest tests/test_preflight_validator.py tests/llm/test_resilience.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7e576a9a8833085e970056ad976c1