### PR TITLE
feat: support LangChain messages in preflight

### DIFF
--- a/tests/test_preflight_messages.py
+++ b/tests/test_preflight_messages.py
@@ -1,0 +1,66 @@
+import logging
+
+import pytest
+from langchain_core.messages import AIMessage, ToolMessage
+
+from orchestrator.llm.preflight import normalize_history, preflight_validate_messages
+
+
+@pytest.fixture(autouse=True)
+def patch_graph():
+    """Override global fixture from conftest; not needed here."""
+    yield
+
+
+def test_assistant_tool_match_unchanged():
+    history = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "a1", "type": "function", "function": {"name": "x", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "a1", "content": "{}"},
+    ]
+    normalized = normalize_history(history)
+    sanitized = preflight_validate_messages(normalized)
+    assert sanitized == history
+
+
+def test_orphan_tool_dropped(caplog):
+    history = [
+        {"role": "user", "content": "hi"},
+        {"role": "tool", "tool_call_id": "oops", "content": "{}"},
+    ]
+    normalized = normalize_history(history)
+    with caplog.at_level(logging.WARNING):
+        sanitized = preflight_validate_messages(normalized)
+    assert sanitized == [history[0]]
+    rec = caplog.records[0]
+    assert rec.message == "drop_orphan_tool"
+
+
+def test_langchain_messages_normalized():
+    ai = AIMessage(content="")
+    ai.tool_calls = [
+        {"id": "a1", "type": "function", "function": {"name": "x", "arguments": {}}}
+    ]
+    history = [ai, ToolMessage(content="{}", tool_call_id="a1")]
+    normalized = normalize_history(history)
+    sanitized = preflight_validate_messages(normalized)
+    assert sanitized == [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "a1",
+                    "type": "function",
+                    "function": {"name": "x", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "content": "{}", "tool_call_id": "a1"},
+    ]
+


### PR DESCRIPTION
## Summary
- normalize chat history that may contain LangChain BaseMessage objects
- drop orphaned tool messages and slice trailing tool exchanges
- sanitize history before invoking LLMs and prefer tool-exchange model during tool calls

## Testing
- `pytest tests/test_preflight_messages.py tests/test_preflight_validator.py tests/llm/test_resilience.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7fddf5fc48330a5d02116df7de055