### PR TITLE
Use contextvars to isolate tool run IDs

### DIFF
--- a/agents/tools.py
+++ b/agents/tools.py
@@ -11,16 +11,9 @@ from orchestrator import stream  # assume stream.register/publish/close exist
 import json
 import asyncio
 
+from agents.tools_context import get_current_run_id
+
 logger = logging.getLogger(__name__)
-
-# Hook global (très simple): si run_id absent des kwargs, essaie de le lire depuis contexte global
-_CURRENT_RUN_ID: str | None = None
-
-
-def set_current_run(run_id: str):  # appelé par run_chat_tools avant l'exec
-    global _CURRENT_RUN_ID
-    _CURRENT_RUN_ID = run_id
-    logger.info("Set current run ID: %s", run_id)
 
 # ---------- Schemas Pydantic v2 ----------
 class CreateItemArgs(BaseModel):
@@ -167,7 +160,7 @@ async def _exec(name: str, run_id: str, args: dict):
 def _mk_tool(name: str, desc: str, schema: type[BaseModel]):
     async def _tool(**kwargs):
         logger.debug("Tool '%s' called with kwargs: %s", name, kwargs)
-        run_id = kwargs.pop("run_id", None) or _CURRENT_RUN_ID
+        run_id = kwargs.pop("run_id", None) or get_current_run_id()
         if not run_id:
             logger.warning("No run_id provided for tool '%s', using 'unknown'", name)
             run_id = "unknown"

--- a/agents/tools_context.py
+++ b/agents/tools_context.py
@@ -1,0 +1,14 @@
+from contextvars import ContextVar
+from typing import Optional
+
+RUN_ID_CTX: ContextVar[Optional[str]] = ContextVar("RUN_ID_CTX", default=None)
+
+
+def set_current_run_id(run_id: str) -> None:
+    """Set the run identifier for the current context."""
+    RUN_ID_CTX.set(run_id)
+
+
+def get_current_run_id() -> Optional[str]:
+    """Return the run identifier for the current context, if any."""
+    return RUN_ID_CTX.get()

--- a/orchestrator/core_loop.py
+++ b/orchestrator/core_loop.py
@@ -10,10 +10,8 @@ from orchestrator.llm.safe_invoke import safe_invoke_with_fallback
 from orchestrator.llm.errors import ProviderExhaustedError
 from orchestrator.llm.factory import build_llm
 from orchestrator.settings import LLM_PROVIDER_ORDER
-from agents.tools import (
-    TOOLS as LC_TOOLS,
-    set_current_run,
-)  # StructuredTool list (async funcs)
+from agents.tools import TOOLS as LC_TOOLS  # StructuredTool list (async funcs)
+from agents.tools_context import set_current_run_id
 from orchestrator import crud, stream
 from orchestrator.prompt_loader import load_prompt
 from orchestrator.storage.services import (
@@ -126,7 +124,7 @@ async def _run_chat_tools_impl(
     logger.info("TOOLS count: %d", len(LC_TOOLS))
 
     # Set the current run context for tools
-    set_current_run(run_id)
+    set_current_run_id(run_id)
 
     # 1) Prépare le modèle + binding outils (LangChain)
     # Verify tools are valid before binding

--- a/tests/test_tools_run_id.py
+++ b/tests/test_tools_run_id.py
@@ -1,6 +1,26 @@
+import asyncio
 import pytest
 from pydantic import BaseModel
+
+import types
+import sys
+
+# Provide a minimal stub for the sqlmodel module required by imports in test fixtures
+sys.modules.setdefault(
+    "sqlmodel",
+    types.SimpleNamespace(
+        Session=object,
+        SQLModel=type("SQLModel", (), {"__init_subclass__": lambda cls, **kw: None}),
+        Column=lambda *a, **k: None,
+        Field=lambda *a, **k: None,
+        Index=lambda *a, **k: None,
+        JSON=object,
+        create_engine=lambda *a, **k: None,
+    ),
+)
+
 import agents.tools as tool_mod
+from agents.tools_context import set_current_run_id, get_current_run_id
 
 
 class Dummy(BaseModel):
@@ -8,15 +28,44 @@ class Dummy(BaseModel):
 
 
 @pytest.mark.asyncio
-async def test_tool_uses_global_run_id(monkeypatch):
+async def test_tool_reads_context_run_id(monkeypatch):
+    """Tool should use run_id from contextvars when not provided."""
     captured = {}
 
     async def fake_exec(name, run_id, args):
         captured["run_id"] = run_id
+        captured["ctx"] = get_current_run_id()
         return "ok"
 
     monkeypatch.setattr(tool_mod, "_exec", fake_exec)
-    tool_mod.set_current_run("abc")
+
+    set_current_run_id("abc")
     tool = tool_mod._mk_tool("t", "desc", Dummy)
     await tool.coroutine()
+
     assert captured["run_id"] == "abc"
+    assert captured["ctx"] == "abc"
+
+
+@pytest.mark.asyncio
+async def test_run_id_context_is_isolated(monkeypatch):
+    """Different async tasks should not leak run_id between each other."""
+    captured = []
+
+    async def fake_exec(name, run_id, args):
+        captured.append((run_id, get_current_run_id()))
+        await asyncio.sleep(0)
+        return "ok"
+
+    monkeypatch.setattr(tool_mod, "_exec", fake_exec)
+    tool = tool_mod._mk_tool("t", "desc", Dummy)
+
+    async def runner(run_id: str):
+        set_current_run_id(run_id)
+        await asyncio.sleep(0)
+        await tool.coroutine()
+
+    await asyncio.gather(runner("one"), runner("two"))
+
+    assert len(captured) == 2
+    assert {("one", "one"), ("two", "two")} == set(captured)


### PR DESCRIPTION
## Summary
- add `tools_context` module providing `set_current_run_id` and `get_current_run_id`
- core loop stores current run ID in contextvars instead of global
- tools read run ID from contextvar for logging and accept explicit `run_id` arg
- add tests ensuring run ID isolation across concurrent runs

## Testing
- `pytest tests/test_tools_run_id.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8097c8b908330b7674340cab0d29b