### PR TITLE
Sanitize tool exchange payloads and log preflight context

### DIFF
--- a/orchestrator/llm/preflight.py
+++ b/orchestrator/llm/preflight.py
@@ -165,6 +165,9 @@ def extract_tool_exchange_slice(msgs: List[MessageLike]) -> Optional[List[Dict[s
         if i - 1 >= 0 and nd[i - 1].get("role") in ("user", "assistant"):
             head.append(nd[i - 1])
         slice_msgs = head + tail
-        return preflight_validate_messages(slice_msgs)
+        validated = preflight_validate_messages(slice_msgs)
+        if not validated or validated[-1].get("role") != "tool":
+            return None
+        return validated
     return None
 

--- a/tests/test_preflight_validator.py
+++ b/tests/test_preflight_validator.py
@@ -92,3 +92,36 @@ def test_non_adjacent_tool_slice(caplog):
 
     slice_msgs = extract_tool_exchange_slice(msgs)
     assert slice_msgs is None
+
+
+def test_tool_exchange_slice_minimal():
+    msgs = [
+        {"role": "system", "content": "s1"},
+        {"role": "user", "content": "u0"},
+        {"role": "system", "content": "s2"},
+        {"role": "user", "content": "u"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "a1", "type": "function", "function": {"name": "x", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "a1", "content": "ok"},
+        {"role": "tool", "tool_call_id": "a1", "content": "more"},
+    ]
+
+    slice_msgs = extract_tool_exchange_slice(msgs)
+    assert slice_msgs == [
+        {"role": "system", "content": "s2"},
+        {"role": "user", "content": "u"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "a1", "type": "function", "function": {"name": "x", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "a1", "content": "ok"},
+        {"role": "tool", "tool_call_id": "a1", "content": "more"},
+    ]

--- a/tests/test_safe_invoke_preflight_debug.py
+++ b/tests/test_safe_invoke_preflight_debug.py
@@ -1,0 +1,50 @@
+import logging
+import pytest
+from langchain_core.messages import AIMessage
+
+from orchestrator.llm import safe_invoke
+from orchestrator.llm.safe_invoke import safe_invoke_with_fallback
+
+
+@pytest.fixture(autouse=True)
+def patch_graph():
+    """Override global fixture from conftest; not needed here."""
+    yield
+
+
+class DummyLLM:
+    def invoke(self, messages):
+        return AIMessage(content="done")
+
+
+class DummyProvider:
+    name = "dummy"
+
+    def make_llm(self, *, tool_phase, tools):
+        return DummyLLM()
+
+
+@pytest.mark.asyncio
+async def test_preflight_debug_logged(caplog, monkeypatch):
+    history = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "a1", "type": "function", "function": {"name": "x", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "a1", "content": "{}"},
+    ]
+
+    monkeypatch.setattr(safe_invoke, "in_tool_exchange", False)
+    monkeypatch.setattr(safe_invoke._bucket, "take", lambda: True)
+
+    provider = DummyProvider()
+    with caplog.at_level(logging.INFO):
+        await safe_invoke_with_fallback([provider], history)
+
+    rec = next(r for r in caplog.records if r.message == "preflight_debug")
+    payload = rec.__dict__["payload"]
+    assert payload["roles"] == ["assistant", "tool"]
+    assert payload["assistant_tc_ids"] == ["a1"]


### PR DESCRIPTION
## Summary
- sanitize message history to drop orphan tool outputs and extract minimal tool-exchange slices
- log sanitized roles and tool call ids prior to LLM invocation
- add regression tests for message normalization, slice extraction and logging

## Testing
- `pytest tests/test_preflight_messages.py tests/test_preflight_validator.py tests/test_safe_invoke_preflight_debug.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b80c0b0b2c8330977ae273a3e322d9