### PR TITLE
feat: show run token costs and breakdown

### DIFF
--- a/frontend/src/app/runs/RunDetail.test.tsx
+++ b/frontend/src/app/runs/RunDetail.test.tsx
@@ -43,7 +43,11 @@ it('shows run details when run exists', async () => {
     })
     .mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ tokens: 0, cost: 0, by_agent: {} }),
+      json: async () => ({
+        total_tokens: 0,
+        cost_eur: 0,
+        by_agent: [],
+      }),
     });
   render(<RunDetail params={{ run_id: '1' }} />);
   expect(await screen.findByText('Run 1')).toBeInTheDocument();

--- a/frontend/src/app/runs/[run_id]/page.tsx
+++ b/frontend/src/app/runs/[run_id]/page.tsx
@@ -98,7 +98,7 @@ export default function RunDetail({ params }: { params: { run_id: string } }) {
           </p>
         )}
       </div>
-      <RunTimeline runId={run.run_id} />
+      <RunTimeline runId={run.run_id} refreshKey={run.status} />
       {run.status === "done" && (
         <div className="space-y-4">
           {run.summary && <p>{run.summary}</p>}

--- a/frontend/src/components/RunTimeline.test.tsx
+++ b/frontend/src/components/RunTimeline.test.tsx
@@ -25,15 +25,24 @@ describe("RunTimeline", () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
-          tokens: 5,
-          cost: 0.1,
-          by_agent: { alpha: { tokens: 5, cost: 0.1 } },
+          total_tokens: 5,
+          cost_eur: 0.1,
+          by_agent: [
+            {
+              agent: "alpha",
+              prompt_tokens: 2,
+              completion_tokens: 3,
+              total_tokens: 5,
+              cost_eur: 0.1,
+            },
+          ],
         }),
       });
 
     render(<RunTimeline runId="1" />);
     expect(await screen.findByText(/Agent alpha/)).toBeInTheDocument();
     expect(screen.getByText(/Tokens: 5/)).toBeInTheDocument();
+    expect(screen.getByText(/€0\.1000/)).toBeInTheDocument();
   });
 
   it("handles fetch error", async () => {
@@ -61,7 +70,11 @@ describe("RunTimeline", () => {
       })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ tokens: 0, cost: 0, by_agent: {} }),
+        json: async () => ({
+          total_tokens: 0,
+          cost_eur: 0,
+          by_agent: [],
+        }),
       })
       .mockResolvedValueOnce({ ok: true, text: async () => "full" });
 

--- a/frontend/src/lib/runs.test.ts
+++ b/frontend/src/lib/runs.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getRunCost } from './runs';
+
+const sample = {
+  total_tokens: 5,
+  cost_eur: 0.1,
+  by_agent: [
+    {
+      agent: 'a',
+      prompt_tokens: 2,
+      completion_tokens: 3,
+      total_tokens: 5,
+      cost_eur: 0.1,
+    },
+  ],
+};
+
+describe('getRunCost', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://api';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches run cost', async () => {
+    const json = vi.fn().mockResolvedValue(sample);
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json });
+    (global as any).fetch = fetchMock;
+
+    const data = await getRunCost('1');
+    expect(fetchMock).toHaveBeenCalledWith('http://api/runs/1/cost', undefined);
+    expect(data).toEqual(sample);
+  });
+
+  it('throws on non-ok response', async () => {
+    (global as any).fetch = vi.fn().mockResolvedValue({ ok: false });
+    await expect(getRunCost('1')).rejects.toThrow('Failed to load run cost');
+  });
+
+  it('propagates network errors', async () => {
+    const err = new Error('net');
+    (global as any).fetch = vi.fn().mockRejectedValue(err);
+    await expect(getRunCost('1')).rejects.toThrow(err);
+  });
+});

--- a/frontend/src/lib/runs.ts
+++ b/frontend/src/lib/runs.ts
@@ -1,0 +1,22 @@
+// src/lib/runs.ts
+import { http } from './api';
+
+export interface AgentCost {
+  agent: string;
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+  cost_eur: number;
+}
+
+export interface RunCost {
+  total_tokens: number;
+  cost_eur: number;
+  by_agent: AgentCost[];
+}
+
+export async function getRunCost(runId: string): Promise<RunCost> {
+  const res = await http(`/runs/${runId}/cost`);
+  if (!res.ok) throw new Error('Failed to load run cost');
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add API client for run cost breakdown
- display token and euro cost with per-agent table
- refresh cost display when run status updates

## Testing
- `npm test -- src/lib/runs.test.ts src/components/RunTimeline.test.tsx src/app/runs/RunDetail.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b813d8bcd08330b56b096650270d5e