### PR TITLE
feat: convert payload to LangChain messages

### DIFF
--- a/orchestrator/llm/preflight.py
+++ b/orchestrator/llm/preflight.py
@@ -116,6 +116,33 @@ def normalize_history(history: List[MessageLike]) -> List[Dict[str, Any]]:
     return [_to_openai_dict(m) for m in history]
 
 
+def to_langchain_messages(msgs: List[Dict[str, Any]]) -> List[BaseMessage]:
+    out: List[BaseMessage] = []
+    for m in msgs:
+        r = m.get("role")
+        if r == "system":
+            out.append(SystemMessage(content=m.get("content", "")))
+        elif r == "user":
+            out.append(HumanMessage(content=m.get("content", "")))
+        elif r == "assistant":
+            out.append(
+                AIMessage(
+                    content=m.get("content", ""),
+                    tool_calls=m.get("tool_calls") or [],  # expects LC shape
+                )
+            )
+        elif r == "tool":
+            out.append(
+                ToolMessage(
+                    content=m.get("content", ""),
+                    tool_call_id=m.get("tool_call_id") or "",
+                )
+            )
+        else:
+            out.append(HumanMessage(content=m.get("content", "")))
+    return out
+
+
 def preflight_validate_messages(msgs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     out: List[Dict[str, Any]] = []
     last_assistant_tool_ids: Optional[Set[str]] = None

--- a/orchestrator/llm/safe_invoke.py
+++ b/orchestrator/llm/safe_invoke.py
@@ -10,6 +10,7 @@ from .preflight import (
     extract_tool_exchange_slice,
     normalize_history,
     preflight_validate_messages,
+    to_langchain_messages,
 )
 from orchestrator.settings import (
     LLM_MAX_RETRIES,
@@ -24,8 +25,10 @@ in_tool_exchange = False
 
 
 async def _invoke_threaded(llm, messages: Sequence[Any]):
+    lc_messages = to_langchain_messages(list(messages))
+
     def _call():
-        return llm.invoke(messages)
+        return llm.invoke(lc_messages)
 
     try:
         return await asyncio.to_thread(_call)

--- a/tests/test_to_langchain_messages.py
+++ b/tests/test_to_langchain_messages.py
@@ -1,0 +1,62 @@
+import pytest
+from orchestrator.llm.preflight import to_langchain_messages
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+
+@pytest.fixture(autouse=True)
+def patch_graph():
+    """Override heavy fixture from tests.conftest."""
+    yield
+
+
+def test_to_langchain_messages_basic_mapping():
+    msgs = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": "ok",
+            "tool_calls": [{"id": "1", "name": "foo", "args": {"x": 1}}],
+        },
+        {"role": "tool", "content": "result", "tool_call_id": "1"},
+    ]
+    lc = to_langchain_messages(msgs)
+    assert isinstance(lc[0], SystemMessage)
+    assert lc[0].content == "sys"
+    assert isinstance(lc[1], HumanMessage)
+    assert lc[1].content == "hi"
+    assert isinstance(lc[2], AIMessage)
+    assert lc[2].tool_calls[0]["name"] == "foo"
+    assert isinstance(lc[3], ToolMessage)
+    assert lc[3].tool_call_id == "1"
+
+
+def test_to_langchain_messages_unknown_role_defaults_to_human():
+    msgs = [{"role": "other", "content": "x"}]
+    lc = to_langchain_messages(msgs)
+    assert isinstance(lc[0], HumanMessage)
+
+
+def test_to_langchain_messages_missing_content_empty_string():
+    msgs = [{"role": "system"}]
+    lc = to_langchain_messages(msgs)
+    assert lc[0].content == ""
+
+
+class DummyLLM:
+    def __init__(self):
+        self.received = None
+
+    def invoke(self, messages):
+        self.received = messages
+        return "ok"
+
+
+@pytest.mark.asyncio
+async def test_invoke_threaded_converts_dicts_to_messages():
+    from orchestrator.llm.safe_invoke import _invoke_threaded
+
+    llm = DummyLLM()
+    result = await _invoke_threaded(llm, [{"role": "user", "content": "hi"}])
+    assert result == "ok"
+    assert isinstance(llm.received[0], HumanMessage)


### PR DESCRIPTION
## Summary
- add `to_langchain_messages` helper to build LangChain `BaseMessage` objects from sanitized dict payloads
- ensure `_invoke_threaded` converts messages before LLM invocation
- add unit tests covering message conversion and threaded invoke

## Testing
- `pytest tests/test_to_langchain_messages.py -q`
- `pytest -q` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68b823351bb4833090219ae21bc472cd