### PR TITLE
fix: sanitize LLM messages before invocation

### DIFF
--- a/tests/test_to_langchain_messages.py
+++ b/tests/test_to_langchain_messages.py
@@ -43,6 +43,28 @@ def test_to_langchain_messages_missing_content_empty_string():
     assert lc[0].content == ""
 
 
+def test_to_langchain_messages_accepts_base_messages():
+    msgs = [SystemMessage(content="sys"), {"role": "user", "content": "hi"}]
+    lc = to_langchain_messages(msgs)
+    assert isinstance(lc[0], SystemMessage)
+    assert isinstance(lc[1], HumanMessage)
+
+
+def test_to_langchain_messages_normalizes_openai_tool_calls():
+    ai = AIMessage(
+        content="ok",
+        additional_kwargs={
+            "tool_calls": [
+                {"id": "1", "function": {"name": "foo", "arguments": "{\"x\":1}"}}
+            ]
+        },
+    )
+    lc = to_langchain_messages([ai])
+    assert lc[0].tool_calls == [
+        {"id": "1", "type": "tool_call", "name": "foo", "args": {"x": 1}}
+    ]
+
+
 class DummyLLM:
     def __init__(self):
         self.received = None


### PR DESCRIPTION
## Summary
- ensure `to_langchain_messages` accepts dicts and `BaseMessage` objects while coercing tool calls to LangChain shape
- sanitize messages in `safe_invoke_with_fallback` via `build_payload_messages`
- add tests for mixed message inputs and OpenAI-style tool call normalization

## Testing
- `pytest tests/test_to_langchain_messages.py tests/test_safe_invoke_preflight_debug.py`

------
https://chatgpt.com/codex/tasks/task_e_68b82c919e448330abb734297a6ca3e5