### PR TITLE
feat(ui): add grouped conversation history turns

### DIFF
--- a/frontend/src/components/history/AgentActionsAccordion.test.tsx
+++ b/frontend/src/components/history/AgentActionsAccordion.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AgentActionsAccordion } from './AgentActionsAccordion';
+import type { AgentAction } from '@/types/conversation';
+
+describe('AgentActionsAccordion', () => {
+  const baseAction: AgentAction = {
+    id: 'a1',
+    label: 'Test Action',
+    status: 'running',
+  } as AgentAction;
+
+  it('is closed by default', () => {
+    render(<AgentActionsAccordion actions={[baseAction]} />);
+    expect(screen.queryByText('Test Action')).not.toBeInTheDocument();
+  });
+
+  it('updates running indicator when action succeeds', () => {
+    const { rerender } = render(<AgentActionsAccordion actions={[baseAction]} />);
+    expect(screen.getByText(/Running: Test Action/)).toBeInTheDocument();
+    rerender(<AgentActionsAccordion actions={[{ ...baseAction, status: 'succeeded' }]} />);
+    expect(screen.queryByText(/Running:/)).not.toBeInTheDocument();
+  });
+
+  it('toggles details JSON', () => {
+    const action: AgentAction = {
+      ...baseAction,
+      status: 'succeeded',
+      debug: { input: { foo: 'bar' } },
+    };
+    render(<AgentActionsAccordion actions={[action]} />);
+    fireEvent.click(screen.getByText('Agent actions (1)'));
+    expect(screen.queryByText('foo')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('Details'));
+    expect(screen.getByText('foo')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Details'));
+    expect(screen.queryByText('foo')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/history/AgentActionsAccordion.tsx
+++ b/frontend/src/components/history/AgentActionsAccordion.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react';
+import { Loader2, Play, CheckCircle, XCircle } from 'lucide-react';
+import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from '@/components/ui/accordion';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import type { AgentAction } from '@/types/conversation';
+import { cn } from '@/lib/utils';
+
+interface AgentActionsAccordionProps {
+  actions: AgentAction[];
+}
+
+const statusColors: Record<AgentAction['status'], string> = {
+  running: 'bg-muted text-muted-foreground',
+  succeeded: 'bg-green-500 text-white',
+  failed: 'bg-red-500 text-white',
+  pending: 'bg-muted text-muted-foreground',
+};
+
+const StatusIcon = ({ status }: { status: AgentAction['status'] }) => {
+  if (status === 'running') return <Play className="h-3 w-3" />;
+  if (status === 'succeeded') return <CheckCircle className="h-3 w-3" />;
+  if (status === 'failed') return <XCircle className="h-3 w-3" />;
+  return <Play className="h-3 w-3" />;
+};
+
+export function AgentActionsAccordion({ actions }: AgentActionsAccordionProps) {
+  const [openDetails, setOpenDetails] = useState<Record<string, boolean>>({});
+  const [open, setOpen] = useState(false);
+  const running = actions.find((a) => a.status === 'running');
+
+  const toggle = (id: string) => setOpenDetails((s) => ({ ...s, [id]: !s[id] }));
+
+  return (
+    <Accordion>
+      <AccordionItem value="actions">
+        <AccordionTrigger onClick={() => setOpen(!open)}>
+          <div className="flex w-full items-center justify-between text-sm">
+            <span>Agent actions ({actions.length})</span>
+            {running && (
+              <span className="ml-2 flex items-center gap-1 text-xs text-muted-foreground">
+                • Running: {running.label}
+                <Loader2 className="h-3 w-3 animate-spin" />
+              </span>
+            )}
+          </div>
+        </AccordionTrigger>
+        <AccordionContent open={open}>
+          <ul className="text-sm">
+            {actions.map((a) => (
+              <li key={a.id} className="border-b last:border-none py-1.5">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2">
+                    <StatusIcon status={a.status} />
+                    <span>{a.label}</span>
+                    <Badge className={cn('text-[10px] px-1', statusColors[a.status])}>{a.status}</Badge>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {a.durationMs !== undefined && (
+                      <span className="text-xs text-muted-foreground">{a.durationMs}ms</span>
+                    )}
+                    {(a.debug?.input || a.debug?.output || a.debug?.error) && (
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="h-6 px-2 text-[10px]"
+                        onClick={() => toggle(a.id)}
+                      >
+                        Details
+                      </Button>
+                    )}
+                  </div>
+                </div>
+                {openDetails[a.id] && (
+                  <div className="mt-1 space-y-1">
+                    {a.debug?.input && (
+                      <pre className="max-h-32 overflow-auto rounded bg-background p-2 text-xs">
+                        {JSON.stringify(a.debug.input, null, 2)}
+                      </pre>
+                    )}
+                    {a.debug?.output && (
+                      <pre className="max-h-32 overflow-auto rounded bg-background p-2 text-xs">
+                        {JSON.stringify(a.debug.output, null, 2)}
+                      </pre>
+                    )}
+                    {a.debug?.error && (
+                      <pre className="max-h-32 overflow-auto rounded bg-background p-2 text-xs text-red-500">
+                        {JSON.stringify(a.debug.error, null, 2)}
+                      </pre>
+                    )}
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+}

--- a/frontend/src/components/history/AgentResponse.tsx
+++ b/frontend/src/components/history/AgentResponse.tsx
@@ -1,0 +1,26 @@
+import { Badge } from '@/components/ui/badge';
+
+interface AgentResponseProps {
+  text?: string;
+  status: 'running' | 'completed' | 'failed';
+}
+
+export function AgentResponse({ text, status }: AgentResponseProps) {
+  const badge =
+    status === 'completed' ? (
+      <Badge className="bg-green-500 text-white text-[10px] px-1">✓</Badge>
+    ) : status === 'failed' ? (
+      <Badge className="bg-red-500 text-white text-[10px] px-1">⚠</Badge>
+    ) : null;
+  return (
+    <div className="flex items-start gap-2">
+      <div className="mr-auto max-w-[78%] rounded-2xl px-3 py-2 bg-muted">
+        <p className="text-sm whitespace-pre-wrap">
+          {text}
+          {status === 'running' && <span className="animate-pulse"> …</span>}
+        </p>
+      </div>
+      {badge}
+    </div>
+  );
+}

--- a/frontend/src/components/history/ConversationHistory.test.tsx
+++ b/frontend/src/components/history/ConversationHistory.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { ConversationHistory } from './ConversationHistory';
+import type { ConversationTurn } from '@/types/conversation';
+
+describe('ConversationHistory', () => {
+  it('sorts turns in descending order', () => {
+    const turns: ConversationTurn[] = [
+      {
+        id: '1',
+        createdAt: '2024-01-01T00:00:00Z',
+        userText: 'Old',
+        actions: [],
+        agentText: 'A',
+        status: 'completed',
+      },
+      {
+        id: '2',
+        createdAt: '2024-01-02T00:00:00Z',
+        userText: 'New',
+        actions: [],
+        agentText: 'B',
+        status: 'completed',
+      },
+    ];
+
+    render(<ConversationHistory turns={turns} />);
+    const cards = screen.getAllByTestId('turn-card');
+    expect(cards[0]).toHaveTextContent('New');
+    expect(cards[1]).toHaveTextContent('Old');
+  });
+});

--- a/frontend/src/components/history/ConversationHistory.tsx
+++ b/frontend/src/components/history/ConversationHistory.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useRunsStore } from '@/stores/useRunsStore';
+import { useMessagesStore } from '@/stores/useMessagesStore';
+import { mapRunsToTurns } from '@/lib/mapRunsToTurns';
+import type { ConversationTurn } from '@/types/conversation';
+import { ConversationTurnCard } from './ConversationTurnCard';
+
+interface Props {
+  turns?: ConversationTurn[];
+}
+
+export function ConversationHistory({ turns: external }: Props) {
+  const runs = useRunsStore((s) => s.runs);
+  const messages = useMessagesStore((s) => s.messages);
+  const turns = useMemo(
+    () => external ?? mapRunsToTurns(runs, messages),
+    [external, runs, messages]
+  );
+  const sorted = useMemo(
+    () => [...turns].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
+    [turns]
+  );
+
+  if (sorted.length === 0) {
+    return <div className="text-sm text-muted-foreground">No conversation yet</div>;
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {sorted.map((t) => (
+        <ConversationTurnCard key={t.id} turn={t} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/history/ConversationHistoryPanel.tsx
+++ b/frontend/src/components/history/ConversationHistoryPanel.tsx
@@ -1,32 +1,5 @@
-import { useCallback, useState } from 'react';
-import type { HistoryRun, Step } from '@/types/history';
-import { UserPromptCard } from './UserPromptCard';
-import { AgentPlanCard } from './AgentPlanCard';
-import { ExecutionTimeline } from './ExecutionTimeline';
-import { FinalAnswerCard } from './FinalAnswerCard';
-import { RightFiltersDrawer, Filters } from './RightFiltersDrawer';
+import { ConversationHistory } from './ConversationHistory';
 
-export function ConversationHistoryPanel({ run }: { run: HistoryRun }) {
-  const [filters, setFilters] = useState<Filters>({ status: 'all', kind: 'all', time: '1h', group: 'run' });
-
-  const predicate = useCallback(
-    (s: Step) => {
-      if (filters.status !== 'all' && s.status !== filters.status) return false;
-      if (filters.kind !== 'all' && s.kind !== filters.kind) return false;
-      return true;
-    },
-    [filters]
-  );
-
-  return (
-    <div className="h-full flex gap-4">
-      <div className="flex-1 min-h-0 overflow-y-auto space-y-4">
-        <UserPromptCard prompt={run.userPrompt} time={run.startedAt} />
-        <AgentPlanCard bullets={run.agentPlan.bullets} rationale={run.agentPlan.rationale} />
-        <ExecutionTimeline steps={run.steps} filter={predicate} />
-        <FinalAnswerCard run={run} />
-      </div>
-      <RightFiltersDrawer onChange={setFilters} />
-    </div>
-  );
+export function ConversationHistoryPanel() {
+  return <ConversationHistory />;
 }

--- a/frontend/src/components/history/ConversationTurnCard.tsx
+++ b/frontend/src/components/history/ConversationTurnCard.tsx
@@ -1,0 +1,14 @@
+import type { ConversationTurn } from '@/types/conversation';
+import { UserMessage } from './UserMessage';
+import { AgentActionsAccordion } from './AgentActionsAccordion';
+import { AgentResponse } from './AgentResponse';
+
+export function ConversationTurnCard({ turn }: { turn: ConversationTurn }) {
+  return (
+    <div data-testid="turn-card" className="rounded-2xl border p-3 md:p-4 bg-card space-y-2">
+      <UserMessage text={turn.userText} timestamp={turn.createdAt} />
+      {turn.actions.length > 0 && <AgentActionsAccordion actions={turn.actions} />}
+      {turn.agentText && <AgentResponse text={turn.agentText} status={turn.status} />}
+    </div>
+  );
+}

--- a/frontend/src/components/history/UserMessage.tsx
+++ b/frontend/src/components/history/UserMessage.tsx
@@ -1,0 +1,18 @@
+import { format } from 'date-fns';
+
+interface UserMessageProps {
+  text: string;
+  timestamp: string;
+}
+
+export function UserMessage({ text, timestamp }: UserMessageProps) {
+  const time = format(new Date(timestamp), 'HH:mm');
+  return (
+    <div className="flex justify-end items-end gap-2">
+      <div className="ml-auto max-w-[78%] rounded-2xl px-3 py-2 bg-primary text-primary-foreground">
+        <p className="text-sm whitespace-pre-wrap">{text}</p>
+      </div>
+      <span className="text-[10px] text-muted-foreground">{time}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/accordion.tsx
+++ b/frontend/src/components/ui/accordion.tsx
@@ -1,0 +1,21 @@
+import { ChevronDown } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export const Accordion = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+
+export const AccordionItem = ({ children }: { value: string; children: React.ReactNode }) => <div>{children}</div>;
+
+export const AccordionTrigger = ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={cn('flex w-full items-center justify-between py-2 font-medium')}
+  >
+    {children}
+    <ChevronDown className="h-4 w-4" />
+  </button>
+);
+
+export const AccordionContent = ({ open, children }: { open: boolean; children: React.ReactNode }) => (
+  open ? <div className="overflow-hidden text-sm"><div className="pb-4 pt-0">{children}</div></div> : null
+);

--- a/frontend/src/lib/mapRunsToTurns.ts
+++ b/frontend/src/lib/mapRunsToTurns.ts
@@ -1,0 +1,58 @@
+import type { RunData, AgentEvent } from '@/stores/useRunsStore';
+import type { Message } from '@/stores/useMessagesStore';
+import type { ConversationTurn, AgentAction } from '@/types/conversation';
+
+const TOOL_LABELS: Record<string, string> = {
+  generate_items_from_parent: 'Generate child items',
+};
+
+function humanize(name: string): string {
+  return name
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function mapEventToAction(event: AgentEvent, id: string): AgentAction {
+  const startedAt = event.ts || event.timestamp;
+  const finishedAt = event.ts || event.timestamp;
+  const status: AgentAction['status'] =
+    event.ok === undefined ? 'running' : event.ok ? 'succeeded' : 'failed';
+  const label = TOOL_LABELS[event.node] || humanize(event.node);
+  const durationMs = startedAt && finishedAt ? Date.parse(finishedAt) - Date.parse(startedAt) : undefined;
+  return {
+    id,
+    label,
+    technicalName: event.node,
+    startedAt,
+    finishedAt: status === 'running' ? undefined : finishedAt,
+    status,
+    durationMs,
+    debug: {
+      input: event.args,
+      output: event.result,
+      error: event.error,
+    },
+  };
+}
+
+export function mapRunsToTurns(
+  runs: Record<string, RunData>,
+  messages: Message[]
+): ConversationTurn[] {
+  return Object.entries(runs).map(([id, run]) => {
+    const userMsg = messages.find((m) => m.runId === id && m.type === 'user');
+    const agentMsg = messages.find((m) => m.runId === id && m.type === 'agent');
+    const actions = run.events
+      .filter((e) => !['user', 'prompt', 'assistant', 'write'].includes(e.node))
+      .map((e, idx) => mapEventToAction(e, `${id}-${idx}`));
+
+    return {
+      id,
+      createdAt: new Date(run.startedAt).toISOString(),
+      userText: userMsg?.content || '',
+      actions,
+      agentText: agentMsg?.content,
+      status: run.status,
+    };
+  });
+}

--- a/frontend/src/types/conversation.ts
+++ b/frontend/src/types/conversation.ts
@@ -1,0 +1,19 @@
+export type AgentAction = {
+  id: string;
+  label: string;
+  technicalName?: string;
+  startedAt?: string;
+  finishedAt?: string;
+  status: 'pending' | 'running' | 'succeeded' | 'failed';
+  durationMs?: number;
+  debug?: { input?: any; output?: any; error?: any };
+};
+
+export type ConversationTurn = {
+  id: string;
+  createdAt: string;
+  userText: string;
+  actions: AgentAction[];
+  agentText?: string;
+  status: 'running' | 'completed' | 'failed';
+};


### PR DESCRIPTION
## Summary
- add ConversationHistory with grouped turns and streaming agent responses
- show tool actions in collapsible accordion with debug details
- map run events to conversation turns for display

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc50690eb4833080819b1befa6630c