### PR TITLE
feat: add safeId helper and replace crypto.randomUUID

### DIFF
--- a/frontend/src/hooks/useAgentStream.ts
+++ b/frontend/src/hooks/useAgentStream.ts
@@ -3,6 +3,7 @@ import { useRunsStore } from "@/stores/useRunsStore";
 import { connectWS } from "@/lib/ws";
 import { useHistory } from "@/store/useHistory";
 import { toLabel } from "@/lib/historyAdapter";
+import { safeId } from "@/lib/safeId";
 
 type RunPhase =
   | "idle"
@@ -120,7 +121,7 @@ export function useAgentStream(
           const turnId = current.realRunId ?? current.tempRunId;
           if (data.node.endsWith(":request")) {
             useHistory.getState().appendAction(turnId, {
-              id: data.id || crypto.randomUUID(),
+              id: data.id || safeId(),
               label: toLabel(data.node),
               technicalName: data.node,
               startedAt: data.ts ? Date.parse(data.ts) : Date.now(),

--- a/frontend/src/hooks/useConversationHistory.ts
+++ b/frontend/src/hooks/useConversationHistory.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import type { ConversationRun, RunEvent } from '@/types/events';
+import { safeId } from '@/lib/safeId';
 
 export interface UseConversationHistoryOptions {
   autoRefresh?: boolean;
@@ -143,7 +144,7 @@ export function useConversationHistory(options: UseConversationHistoryOptions = 
   // Start a new conversation run
   const startConversation = useCallback(async (objective: string, projectId?: number) => {
     try {
-      const requestId = crypto.randomUUID();
+      const requestId = safeId();
       
       const response = await fetch('/api/agent/run_chat_tools', {
         method: 'POST',

--- a/frontend/src/lib/safeId.test.ts
+++ b/frontend/src/lib/safeId.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+
+const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('safeId', () => {
+  it('uses crypto.randomUUID when available', async () => {
+    const { safeId } = await import('./safeId');
+    const spy = vi.spyOn(globalThis.crypto, 'randomUUID');
+    const id = safeId();
+    expect(spy).toHaveBeenCalled();
+    expect(id).toMatch(UUID_V4_REGEX);
+    spy.mockRestore();
+  });
+
+  it('generates a v4 UUID without crypto.randomUUID', async () => {
+    const originalRandomUUID = globalThis.crypto.randomUUID;
+    Object.defineProperty(globalThis.crypto, 'randomUUID', { value: undefined, configurable: true });
+
+    const { safeId } = await import('./safeId');
+    const id = safeId();
+
+    expect(id).toMatch(UUID_V4_REGEX);
+
+    Object.defineProperty(globalThis.crypto, 'randomUUID', { value: originalRandomUUID, configurable: true });
+  });
+
+  it('generates a v4 UUID without any crypto API', async () => {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'crypto');
+    Object.defineProperty(globalThis, 'crypto', { value: undefined, configurable: true });
+
+    const { safeId } = await import('./safeId');
+    const id = safeId();
+
+    expect(id).toMatch(UUID_V4_REGEX);
+
+    if (originalDescriptor) {
+      Object.defineProperty(globalThis, 'crypto', originalDescriptor);
+    }
+  });
+});

--- a/frontend/src/lib/safeId.ts
+++ b/frontend/src/lib/safeId.ts
@@ -1,0 +1,37 @@
+export function safeId(): string {
+  // Browser with modern Web Crypto
+  const g = typeof globalThis !== "undefined" ? (globalThis as { crypto?: Crypto; msCrypto?: Crypto }) : {};
+  const c: Crypto | undefined = g.crypto || g.msCrypto; // IE fallback if ever
+
+  if (c?.randomUUID) {
+    return c.randomUUID();
+  }
+
+  // Node.js >= 14.17 has crypto.randomUUID
+  try {
+    // avoid bundlers complaining on client
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const nodeCrypto = require("crypto");
+    if (nodeCrypto?.randomUUID) return nodeCrypto.randomUUID();
+  } catch {}
+
+  // Fallback UUID v4 (RFC 4122) using getRandomValues if available
+  const bytes = new Uint8Array(16);
+  if (c?.getRandomValues) c.getRandomValues(bytes);
+  else {
+    // last-resort: Math.random (not cryptographically secure)
+    for (let i = 0; i < 16; i++) bytes[i] = Math.floor(Math.random() * 256);
+  }
+  // Per RFC 4122 v4
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const toHex = (n: number) => n.toString(16).padStart(2, "0");
+  const hex = Array.from(bytes, toHex).join("");
+  return (
+    hex.slice(0, 8) + "-" +
+    hex.slice(8, 12) + "-" +
+    hex.slice(12, 16) + "-" +
+    hex.slice(16, 20) + "-" +
+    hex.slice(20)
+  );
+}

--- a/frontend/src/pages/AgentShell.tsx
+++ b/frontend/src/pages/AgentShell.tsx
@@ -16,6 +16,7 @@ import { useMessagesStore, type Message } from "@/stores/useMessagesStore";
 import { useHistory } from "@/store/useHistory";
 import { toast } from "sonner";
 import { APP_CONFIG } from "@/lib/constants";
+import { safeId } from "@/lib/safeId";
 
 export function AgentShell() {
   const [activeTab, setActiveTab] = useState("backlog");
@@ -85,7 +86,7 @@ export function AgentShell() {
       return;
     }
 
-    const tempRunId = crypto.randomUUID();
+    const tempRunId = safeId();
     useHistory.getState().createTurn(tempRunId, objective);
 
     const userMessage: Message = {


### PR DESCRIPTION
## Summary
- add safeId() utility to generate UUIDs across environments
- use safeId in AgentShell and hooks instead of crypto.randomUUID
- test safeId generation across missing crypto scenarios

## Testing
- `pnpm lint` *(fails: many existing lint errors)*
- `pnpm test --run src/lib/safeId.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bc90f10914833093c35e703002679f