### PR TITLE
feat: add agent actions panel

### DIFF
--- a/frontend/src/components/history/AgentActionsPanel.test.tsx
+++ b/frontend/src/components/history/AgentActionsPanel.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AgentActionsPanel } from './AgentActionsPanel';
+import { useAgentActionsStore } from '@/hooks/useAgentActions';
+
+describe('AgentActionsPanel', () => {
+  const runId = 'r1';
+  beforeEach(() => {
+    useAgentActionsStore.getState().clear();
+  });
+
+  it('shows actions and expands payload', () => {
+    useAgentActionsStore.getState().addFromMessage({
+      run_id: runId,
+      node: 'tool:test:request',
+      args: { foo: 'bar' },
+    });
+    render(<AgentActionsPanel runId={runId} />);
+    expect(screen.getByText('Agent actions (1)')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText(/foo/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/history/AgentActionsPanel.tsx
+++ b/frontend/src/components/history/AgentActionsPanel.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useState } from 'react';
+import { useAgentActions } from '@/hooks/useAgentActions';
+
+interface Props {
+  runId?: string;
+}
+
+export function AgentActionsPanel({ runId }: Props) {
+  const { actions, done } = useAgentActions(runId);
+  const [openIds, setOpenIds] = useState<Record<string, boolean>>({});
+
+  const toggle = (id: string) => {
+    setOpenIds((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  const formatTime = (ts: number) => new Date(ts).toLocaleTimeString();
+
+  const badge = (a: { phase: string; ok?: boolean }) => {
+    if (a.phase === 'request') return '→ request';
+    if (a.phase === 'response') {
+      return a.ok === false ? '✗ response' : '✓ response';
+    }
+    return a.phase;
+  };
+
+  return (
+    <div className="border rounded-md overflow-hidden">
+      <div className="flex items-center justify-between px-3 py-2 border-b text-sm font-medium">
+        <span>Agent actions ({actions.length})</span>
+        {done && <span className="text-xs text-green-600">Done</span>}
+      </div>
+      <div className="max-h-96 overflow-y-auto divide-y text-sm">
+        {actions.map((a) => (
+          <div key={a.id} className="px-3 py-2">
+            <button
+              className="w-full text-left flex items-start justify-between"
+              onClick={() => toggle(a.id)}
+            >
+              <div className="flex items-center gap-2">
+                <span>⚙️</span>
+                <code>{a.tool}</code>
+                <span className="text-xs opacity-70">{badge(a)}</span>
+              </div>
+              <span className="text-xs opacity-70">{formatTime(a.createdAt)}</span>
+            </button>
+            {openIds[a.id] && (
+              <pre className="mt-1 bg-muted rounded p-2 text-xs max-h-40 overflow-auto">
+                {JSON.stringify(a.payload, null, 2)}
+              </pre>
+            )}
+          </div>
+        ))}
+        {!actions.length && (
+          <div className="px-3 py-2 text-xs text-muted-foreground">
+            No actions yet
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useAgentActions.test.ts
+++ b/frontend/src/hooks/useAgentActions.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useAgentActionsStore } from './useAgentActions';
+
+const runId = 'run1';
+
+function add(msg: any) {
+  useAgentActionsStore.getState().addFromMessage({ run_id: runId, ...msg });
+}
+
+describe('useAgentActions store', () => {
+  beforeEach(() => {
+    useAgentActionsStore.getState().clear();
+  });
+
+  it('adds request and response actions and dedupes', () => {
+    add({ node: 'tool:list:request', args: { a: 1 } });
+    add({ node: 'tool:list:request', args: { a: 1 } });
+    let actions = Object.values(useAgentActionsStore.getState().actions[runId]);
+    expect(actions).toHaveLength(1);
+    add({ node: 'tool:list:response', data: { ok: true }, ok: true });
+    actions = Object.values(useAgentActionsStore.getState().actions[runId]);
+    expect(actions).toHaveLength(2);
+    const response = actions.find(a => a.phase === 'response');
+    expect(response?.ok).toBe(true);
+  });
+
+  it('handles error responses', () => {
+    add({ node: 'tool:fail:response', ok: false, data: { err: 'x' } });
+    const actions = Object.values(useAgentActionsStore.getState().actions[runId]);
+    expect(actions[0].ok).toBe(false);
+  });
+
+  it('clears actions by run', () => {
+    add({ node: 'tool:list:request' });
+    expect(Object.keys(useAgentActionsStore.getState().actions)).toHaveLength(1);
+    useAgentActionsStore.getState().clear(runId);
+    expect(Object.keys(useAgentActionsStore.getState().actions)).toHaveLength(0);
+  });
+});

--- a/frontend/src/hooks/useAgentActions.ts
+++ b/frontend/src/hooks/useAgentActions.ts
@@ -1,0 +1,111 @@
+import { create } from 'zustand';
+import { useMemo } from 'react';
+
+export type AgentActionPhase = 'request' | 'response' | 'unknown';
+export type AgentAction = {
+  id: string;
+  runId: string;
+  tool: string;
+  phase: AgentActionPhase;
+  createdAt: number;
+  payload: any;
+  ok?: boolean;
+};
+
+type ActionsByRun = Record<string, Record<string, AgentAction>>;
+
+type AgentActionsState = {
+  actions: ActionsByRun;
+  done: Record<string, boolean>;
+  addFromMessage: (msg: any) => void;
+  clear: (runId?: string) => void;
+};
+
+function hashString(str: string): string {
+  let hash = 2166136261;
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i);
+    hash +=
+      (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24);
+  }
+  return (hash >>> 0).toString(16);
+}
+
+function deriveToolPhase(msg: any): { tool?: string; phase: AgentActionPhase } {
+  if (msg.tool && msg.phase) {
+    return { tool: msg.tool, phase: msg.phase };
+  }
+  const node: string | undefined = msg.node;
+  if (typeof node === 'string' && node.startsWith('tool:')) {
+    const parts = node.split(':');
+    return { tool: parts[1], phase: (parts[2] as AgentActionPhase) || 'unknown' };
+  }
+  return { phase: 'unknown' };
+}
+
+export const useAgentActionsStore = create<AgentActionsState>((set) => ({
+  actions: {},
+  done: {},
+  addFromMessage: (msg: any) =>
+    set((state) => {
+      const runId: string | undefined = msg.run_id;
+      if (!runId) return state;
+
+      if (msg.status === 'done') {
+        return { ...state, done: { ...state.done, [runId]: true } };
+      }
+
+      const { tool, phase } = deriveToolPhase(msg);
+      if (!tool) return state;
+
+      const payload =
+        phase === 'request'
+          ? msg.args || msg.data || {}
+          : phase === 'response'
+          ? msg.data || msg.result || {}
+          : msg.args || msg.data || msg.result || {};
+      const ok = phase === 'response' ? msg.ok ?? true : undefined;
+      const hash = hashString(
+        JSON.stringify(payload).slice(0, 512),
+      );
+      const id = `${runId}:${tool}:${phase}:${hash}`;
+      const runActions = state.actions[runId] || {};
+      if (runActions[id]) return state; // dedupe
+      const action: AgentAction = {
+        id,
+        runId,
+        tool,
+        phase,
+        createdAt: Date.now(),
+        payload,
+        ok,
+      };
+      return {
+        actions: {
+          ...state.actions,
+          [runId]: { ...runActions, [id]: action },
+        },
+      };
+    }),
+  clear: (runId?: string) =>
+    set((state) => {
+      if (!runId) return { actions: {}, done: {} };
+      const { [runId]: _removed, ...rest } = state.actions;
+      const { [runId]: _d, ...restDone } = state.done;
+      return { actions: rest, done: restDone };
+    }),
+}));
+
+export function useAgentActions(runId: string | undefined) {
+  const actionsMap = useAgentActionsStore((s) =>
+    runId ? s.actions[runId] : undefined,
+  );
+  const done = useAgentActionsStore((s) => !!(runId && s.done[runId]));
+  const actions = useMemo(() => {
+    if (!actionsMap) return [] as AgentAction[];
+    return Object.values(actionsMap).sort((a, b) => b.createdAt - a.createdAt);
+  }, [actionsMap]);
+  const addFromMessage = useAgentActionsStore((s) => s.addFromMessage);
+  const clear = useAgentActionsStore((s) => s.clear);
+  return { actions, addFromMessage, clear, done };
+}

--- a/frontend/src/hooks/useAgentStream.ts
+++ b/frontend/src/hooks/useAgentStream.ts
@@ -3,6 +3,7 @@ import { useRunsStore } from "@/stores/useRunsStore";
 import { useHistory } from "@/store/useHistory";
 import { toLabel } from "@/lib/historyAdapter";
 import { safeId } from "@/lib/safeId";
+import { useAgentActionsStore } from "@/hooks/useAgentActions";
 
 // Phases for a run lifecycle
 export type RunPhase =
@@ -117,6 +118,9 @@ export function useAgentStream(
 
     cleanupRun("startRun:pre");
 
+    // reset actions for new run
+    useAgentActionsStore.getState().clear();
+
     const tempRunId = runId ?? safeId();
     runRef.current = {
       tempRunId,
@@ -150,6 +154,8 @@ export function useAgentStream(
         if (!runRef.current || r.wsId !== runRef.current.wsId) return;
         const msg = JSON.parse(ev.data);
         const current = runRef.current!;
+        // forward to agent actions store
+        useAgentActionsStore.getState().addFromMessage(msg);
 
         if (msg.status === "started" && msg.run_id) {
           if (!current.realRunId) {

--- a/frontend/src/pages/AgentShell.tsx
+++ b/frontend/src/pages/AgentShell.tsx
@@ -12,6 +12,7 @@ import { ChatComposer } from "@/components/chat/ChatComposer";
 import { BacklogPanel } from "@/components/backlog/BacklogPanel";
 import { ProjectPanel } from "@/components/project/ProjectPanel";
 import ConversationHistory from "@/components/history/ConversationHistory";
+import { AgentActionsPanel } from "@/components/history/AgentActionsPanel";
 import { useMessagesStore, type Message } from "@/stores/useMessagesStore";
 import { useHistory } from "@/store/useHistory";
 import { toast } from "sonner";
@@ -185,7 +186,10 @@ export function AgentShell() {
             </TabsContent>
 
             <TabsContent value="history" className="flex-1 m-0">
-              <ConversationHistory />
+              <div className="p-2 flex flex-col gap-2">
+                <AgentActionsPanel runId={currentRunId} />
+                <ConversationHistory />
+              </div>
             </TabsContent>
           </div>
         </Tabs>
@@ -220,7 +224,8 @@ export function AgentShell() {
           <BacklogPanel />
         </div>
 
-        <div className="w-1/4">
+        <div className="w-1/4 p-2 flex flex-col gap-2">
+          <AgentActionsPanel runId={currentRunId} />
           <ConversationHistory />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- track agent tool calls in zustand store with deduping per run
- display live agent actions in new panel and integrate into shell layout
- forward websocket events to panel and add basic tests

## Testing
- `pnpm test src/hooks/useAgentActions.test.ts src/components/history/AgentActionsPanel.test.tsx --run`
- `pnpm test` *(fails: Missing `Description` or `aria-describedby` for {DialogContent}; Error fetching runs, useBacklog must be used within BacklogProvider, etc)*

------
https://chatgpt.com/codex/tasks/task_e_68bd56eee590833083590e2f03bf4ade