### PR TITLE
feat: add run stream hook and agent actions UI

### DIFF
--- a/frontend/src/hooks/useRunStream.test.ts
+++ b/frontend/src/hooks/useRunStream.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useRunStream, parseNode } from './useRunStream';
+
+class MockWebSocket {
+  url: string;
+  onopen: (() => void) | null = null;
+  sent: string[] = [];
+  static last?: MockWebSocket;
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.last = this;
+    setTimeout(() => this.onopen && this.onopen(), 0);
+  }
+  send(data: string) {
+    this.sent.push(data);
+  }
+  close() {}
+}
+
+global.WebSocket = MockWebSocket as any;
+
+describe('parseNode', () => {
+  it('parses tool nodes', () => {
+    expect(parseNode('tool:foo:request')).toEqual({ kind: 'tool', tool: 'foo', phase: 'request' });
+  });
+  it('parses write nodes', () => {
+    expect(parseNode('write')).toEqual({ kind: 'write' });
+  });
+  it('throws on unknown node', () => {
+    expect(() => parseNode('x')).toThrow();
+  });
+});
+
+describe('useRunStream', () => {
+  beforeEach(() => {
+    MockWebSocket.last = undefined;
+  });
+
+  it('starts idle and opens websocket on start', () => {
+    const { result } = renderHook(() => useRunStream({ projectId: 1, autoStart: false }));
+    expect(result.current.status).toBe('idle');
+    act(() => result.current.start());
+    expect(MockWebSocket.last).toBeDefined();
+  });
+});

--- a/frontend/src/hooks/useRunStream.ts
+++ b/frontend/src/hooks/useRunStream.ts
@@ -1,0 +1,244 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type AgentStep = {
+  id: string;
+  tool: string;
+  startedAt: number;
+  finishedAt?: number;
+  request: any;
+  result?: any;
+  ok?: boolean;
+  error?: string | null;
+  state: 'pending' | 'running' | 'success' | 'failed';
+};
+
+export type ChatMessage = {
+  id: string;
+  ts: number;
+  text: string;
+};
+
+export function parseNode(
+  node: string,
+):
+  | { kind: 'tool'; phase: 'request' | 'response'; tool: string }
+  | { kind: 'write' } {
+  if (node === 'write') return { kind: 'write' };
+  if (node.startsWith('tool:')) {
+    const [, tool, phase] = node.split(':');
+    return { kind: 'tool', tool, phase: phase as 'request' | 'response' };
+  }
+  throw new Error('Unknown node: ' + node);
+}
+
+function getClientSessionId(): string {
+  try {
+    const key = 'client_session_id';
+    let id = typeof localStorage !== 'undefined' ? localStorage.getItem(key) : null;
+    if (!id) {
+      id = crypto.randomUUID();
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem(key, id);
+      }
+    }
+    return id;
+  } catch {
+    return crypto.randomUUID();
+  }
+}
+
+interface UseRunStreamOptions {
+  objective?: string;
+  projectId: number;
+  autoStart: boolean;
+}
+
+export function useRunStream(options: UseRunStreamOptions) {
+  const { objective, projectId, autoStart } = options;
+  const [runId, setRunId] = useState<string>();
+  const [status, setStatus] = useState<'idle' | 'running' | 'done' | 'error'>('idle');
+  const [steps, setSteps] = useState<AgentStep[]>([]);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const manualClose = useRef(false);
+  const seqRef = useRef<Record<string, number>>({});
+  const reconnectTimer = useRef<number>();
+
+  const getWsUrl = () => {
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    return `${protocol}//${window.location.host}/stream`;
+  };
+
+  const closeSocket = () => {
+    if (wsRef.current) {
+      try {
+        wsRef.current.close();
+      } catch {
+        /* noop */
+      }
+      wsRef.current = null;
+    }
+  };
+
+  const handleMessage = (ev: MessageEvent) => {
+    try {
+      const msg = JSON.parse(ev.data);
+      if (msg.status === 'started' || msg.status === 'existing' || msg.status === 'subscribed') {
+        if (msg.run_id) {
+          setRunId(msg.run_id);
+          setStatus('running');
+        }
+        return;
+      }
+      if (msg.status === 'done') {
+        if (status !== 'error') {
+          setStatus('done');
+        }
+        closeSocket();
+        return;
+      }
+      if (msg.node) {
+        const parsed = parseNode(msg.node);
+        if (parsed.kind === 'write' && msg.summary) {
+          setMessages((m) => [
+            ...m,
+            { id: `m${Date.now()}`, ts: Date.now(), text: msg.summary },
+          ]);
+          return;
+        }
+        if (parsed.kind === 'tool') {
+          const tool = parsed.tool;
+          if (parsed.phase === 'request') {
+            const seq = (seqRef.current[tool] = (seqRef.current[tool] || 0) + 1);
+            const id = `${tool}_${seq}`;
+            setSteps((s) => [
+              ...s,
+              {
+                id,
+                tool,
+                startedAt: Date.now(),
+                request: msg.args ?? {},
+                state: 'running',
+              },
+            ]);
+            return;
+          }
+          if (parsed.phase === 'response') {
+            setSteps((s) => {
+              const idx = [...s].reverse().findIndex(
+                (st) => st.tool === tool && st.state === 'running',
+              );
+              if (idx === -1) {
+                const seq = (seqRef.current[tool] = (seqRef.current[tool] || 0) + 1);
+                return [
+                  ...s,
+                  {
+                    id: `${tool}_${seq}`,
+                    tool,
+                    startedAt: Date.now(),
+                    finishedAt: Date.now(),
+                    request: {},
+                    ok: false,
+                    error: 'orphan_response',
+                    state: 'failed',
+                  },
+                ];
+              }
+              const realIdx = s.length - 1 - idx;
+              const step = s[realIdx];
+              const ok = msg.ok !== false;
+              const updated: AgentStep = {
+                ...step,
+                finishedAt: Date.now(),
+                result: msg.result ?? undefined,
+                ok,
+                error: msg.error ?? null,
+                state: ok ? 'success' : 'failed',
+              };
+              if (!ok) {
+                setStatus('error');
+                setError(msg.error || 'error');
+              }
+              const newSteps = [...s];
+              newSteps[realIdx] = updated;
+              return newSteps;
+            });
+            return;
+          }
+        }
+      }
+    } catch (e) {
+      // ignore malformed messages
+    }
+  };
+
+  const openSocket = useCallback(() => {
+    manualClose.current = false;
+    closeSocket();
+    const ws = new WebSocket(getWsUrl());
+    wsRef.current = ws;
+    ws.onmessage = handleMessage;
+    ws.onclose = () => {
+      if (!manualClose.current && status === 'running' && runId) {
+        const timer = window.setTimeout(() => {
+          openSocket();
+          if (wsRef.current && runId) {
+            wsRef.current.onopen = () => {
+              try {
+                wsRef.current?.send(
+                  JSON.stringify({ action: 'subscribe', run_id: runId }),
+                );
+              } catch {
+                /* noop */
+              }
+            };
+          }
+        }, 1000);
+        reconnectTimer.current = timer;
+      }
+    };
+  }, [runId, status]);
+
+  const start = useCallback(() => {
+    setSteps([]);
+    setMessages([]);
+    setRunId(undefined);
+    setError(null);
+    setStatus('idle');
+    seqRef.current = {};
+    openSocket();
+    const ws = wsRef.current;
+    if (!ws) return;
+    ws.onopen = () => {
+      const payload: any = {
+        action: 'start',
+        objective: objective ?? '',
+        project_id: projectId,
+        client_session_id: getClientSessionId(),
+      };
+      ws.send(JSON.stringify(payload));
+    };
+  }, [objective, projectId, openSocket]);
+
+  const stop = useCallback(() => {
+    manualClose.current = true;
+    setStatus('idle');
+    closeSocket();
+  }, []);
+
+  useEffect(() => {
+    if (autoStart) {
+      start();
+    }
+    return () => {
+      manualClose.current = true;
+      closeSocket();
+      if (reconnectTimer.current) window.clearTimeout(reconnectTimer.current);
+    };
+  }, [autoStart, start]);
+
+  return { runId, status, steps, messages, start, stop, error };
+}
+


### PR DESCRIPTION
## Summary
- add WebSocket-based `useRunStream` hook with auto-reconnect and step tracking
- display real-time step list with status icons and details in AgentActionsPanel
- cover stream parsing and panel logic with unit tests

## Testing
- `pnpm test` *(fails: BacklogPane tests require BacklogProvider)*
- `pnpm test src/hooks/useRunStream.test.ts src/components/history/AgentActionsPanel.test.tsx --run`

------
https://chatgpt.com/codex/tasks/task_e_68bdd479e8988330a17caf8b41959bdf