### PR TITLE
fix: handle missing agent steps

### DIFF
--- a/frontend/src/components/history/AgentActionsPanel.test.tsx
+++ b/frontend/src/components/history/AgentActionsPanel.test.tsx
@@ -28,4 +28,10 @@ describe('AgentActionsPanel', () => {
     render(<AgentActionsPanel steps={steps} status="error" />);
     expect(screen.getByText(/Failed: boom/)).toBeInTheDocument();
   });
+
+  it('renders safely when steps are missing', () => {
+    render(<AgentActionsPanel status="idle" />);
+    expect(screen.getByText('Agent actions (0)')).toBeInTheDocument();
+    expect(screen.getByText('No actions yet')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/history/AgentActionsPanel.tsx
+++ b/frontend/src/components/history/AgentActionsPanel.tsx
@@ -5,11 +5,11 @@ import { AgentStep } from '@/hooks/useRunStream';
 import { Loader2, CheckCircle, AlertCircle } from 'lucide-react';
 
 interface Props {
-  steps: AgentStep[];
+  steps?: AgentStep[];
   status: 'idle' | 'running' | 'done' | 'error';
 }
 
-export function AgentActionsPanel({ steps, status }: Props) {
+export function AgentActionsPanel({ steps = [], status }: Props) {
   const [open, setOpen] = useState<Record<string, boolean>>({});
   const toggle = (id: string) => setOpen((p) => ({ ...p, [id]: !p[id] }));
 


### PR DESCRIPTION
## Summary
- prevent AgentActionsPanel from crashing when no steps are provided
- test that AgentActionsPanel renders safely without steps

## Testing
- `pnpm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_68be6e8637b88330ab797d13b1da9c97