### PR TITLE
Persist websocket runs for conversation history

### DIFF
--- a/api/ws.py
+++ b/api/ws.py
@@ -12,6 +12,7 @@ import logging
 from orchestrator.core_loop import run_chat_tools
 from orchestrator import crud, stream
 from orchestrator.run_registry import get_or_create_run
+from orchestrator.events import start_run
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -116,6 +117,10 @@ async def stream_chat(ws: WebSocket):
                 queue = stream.register(run_id)
 
             if created:
+                # Persist run and initialize event tracking
+                crud.create_run(run_id, objective, project_id, None)
+                start_run(run_id)
+
                 # Fresh run for this client: cancel any previous task for the same client (defensive)
                 if client_id in RUNNING_TASKS:
                     old_task = RUNNING_TASKS[client_id]

--- a/tests/test_ws_run_creation.py
+++ b/tests/test_ws_run_creation.py
@@ -1,0 +1,20 @@
+import asyncio
+import pytest
+from httpx import AsyncClient
+from httpx_ws import aconnect_ws
+from httpx_ws.transport import ASGIWebSocketTransport
+from api.main import app
+from orchestrator import crud
+
+crud.init_db()
+transport = ASGIWebSocketTransport(app=app)
+
+@pytest.mark.asyncio
+async def test_ws_start_creates_run():
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        async with aconnect_ws("http://test/stream", ac) as ws:
+            await ws.send_json({"objective": "demo"})
+            first = await ws.receive_json()
+            run_id = first["run_id"]
+    run = crud.get_run(run_id)
+    assert run is not None


### PR DESCRIPTION
## Summary
- ensure websocket-started runs are persisted and events tracking initialized
- add regression test confirming run is created when websocket session starts

## Testing
- `pytest tests/test_ws_run_creation.py::test_ws_start_creates_run -q`
- `pytest tests/test_api.py::test_ws_stream_new_run -q` *(fails: AssertionError: assert [] == ['plan', 'execute', 'write'])*


------
https://chatgpt.com/codex/tasks/task_e_68be707d95a883309c2bd3ca0ec09aac