### PR TITLE
fix: handle dagre edges without labels

### DIFF
--- a/frontend/src/components/backlog/DiagramView.test.ts
+++ b/frontend/src/components/backlog/DiagramView.test.ts
@@ -1,0 +1,28 @@
+import dagre from 'dagre';
+
+describe('dagre layout', () => {
+  function layoutWithDefaultEdges(count: number) {
+    const g = new dagre.graphlib.Graph();
+    g.setGraph({});
+    g.setDefaultEdgeLabel(() => ({}));
+    for (let i = 0; i < count; i++) {
+      g.setNode(i, { width: 100, height: 40 });
+      if (i > 0) g.setEdge(i - 1, i);
+    }
+    dagre.layout(g);
+    return g.nodes().length;
+  }
+
+  it('handles many nodes when edges have labels', () => {
+    expect(() => layoutWithDefaultEdges(50)).not.toThrow();
+  });
+
+  it('throws when edge labels are missing', () => {
+    const g = new dagre.graphlib.Graph();
+    g.setGraph({});
+    g.setNode(0, { width: 100, height: 40 });
+    g.setNode(1, { width: 100, height: 40 });
+    g.setEdge(0, 1); // missing label
+    expect(() => dagre.layout(g)).toThrow();
+  });
+});

--- a/frontend/src/components/backlog/DiagramView.tsx
+++ b/frontend/src/components/backlog/DiagramView.tsx
@@ -110,6 +110,7 @@ export function DiagramView({ projectId }: DiagramViewProps) {
     if (nodes.length === 0 || edges.length === 0) return;
     const g = new dagre.graphlib.Graph();
     g.setGraph({ rankdir: 'LR', nodesep: 40, ranksep: 80 });
+    g.setDefaultEdgeLabel(() => ({}));
     nodes.forEach(nd => g.setNode(nd.id, { width: nd.width, height: nd.height, rank: nd.rank }));
     edges.forEach(e => g.setEdge(e.source, e.target));
     dagre.layout(g);


### PR DESCRIPTION
## Summary
- ensure dagre edges have default labels to avoid runtime TypeError when layouting many backlog nodes
- add regression test for dagre edge labels

## Testing
- `npm test` *(fails: Error [ERR_REQUIRE_ESM] require() of ES Module vite/dist/node/index.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bed9cad1a48330a0a6b7ba7cd646bf