### PR TITLE
feat(frontend): allow title click to edit backlog items

### DIFF
--- a/frontend/src/components/BacklogTable.tsx
+++ b/frontend/src/components/BacklogTable.tsx
@@ -279,7 +279,7 @@ export function BacklogTable({ projectId, onEdit }: BacklogTableProps) {
                       {item.generated_by_ai && (
                         <Badge className="bg-purple-600 text-white text-xs flex items-center gap-1">
                           <CpuIcon className="w-3 h-3" />
-                          IA - à valider
+                          IA
                         </Badge>
                       )}
                     </div>

--- a/frontend/src/components/BacklogTable.tsx
+++ b/frontend/src/components/BacklogTable.tsx
@@ -267,7 +267,15 @@ export function BacklogTable({ projectId, onEdit }: BacklogTableProps) {
                 <td className="px-4 py-3">
                   <div>
                     <div className="flex items-center gap-2">
-                      <span className="font-medium">{item.title}</span>
+                      <span
+                        className="font-medium cursor-pointer"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onEdit(item);
+                        }}
+                      >
+                        {item.title}
+                      </span>
                       {item.generated_by_ai && (
                         <Badge className="bg-purple-600 text-white text-xs flex items-center gap-1">
                           <CpuIcon className="w-3 h-3" />

--- a/frontend/src/components/BacklogViewTabs.tsx
+++ b/frontend/src/components/BacklogViewTabs.tsx
@@ -33,7 +33,7 @@ export function BacklogViewTabs({ projectId, onEdit }: BacklogViewTabsProps) {
 
       <TabsContent value="diagram" className="flex-1 min-h-0 overflow-y-auto mt-0">
         <div className="h-full overflow-y-auto">
-          <DiagramView projectId={projectId} />
+          <DiagramView projectId={projectId} onEdit={onEdit} />
         </div>
       </TabsContent>
     </Tabs>

--- a/frontend/src/components/ItemTree.tsx
+++ b/frontend/src/components/ItemTree.tsx
@@ -165,7 +165,12 @@ function Item({ item, onEdit, level = 0, collapsed, toggle, onDragStart, onDrop 
         </div>
 
         <div className="flex-1 flex items-center gap-2">
-          <span>{item.title}</span>
+          <span
+            className="cursor-pointer font-medium"
+            onClick={() => onEdit(item)}
+          >
+            {item.title}
+          </span>
           {item.generated_by_ai && (
             <Badge className="bg-purple-600 text-white text-xs flex items-center gap-1">
               <CpuIcon className="w-3 h-3" />

--- a/frontend/src/components/__tests__/AIBadge.test.tsx
+++ b/frontend/src/components/__tests__/AIBadge.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { BacklogTable } from '../BacklogTable';
+import { ItemTree } from '../ItemTree';
+import { DiagramView } from '../backlog/DiagramView';
+import { ItemDialog } from '../ItemDialog';
+import { useItems } from '@/lib/hooks';
+
+vi.mock('@/lib/hooks', () => ({ useItems: vi.fn() }));
+vi.mock('@/context/BacklogContext', () => ({ useBacklog: () => ({ deleteItem: vi.fn() }) }));
+vi.mock('@/components/backlog/useAutoFit', () => ({ useAutoFit: () => () => {} }));
+vi.mock('@/lib/layout', () => ({ getLayout: vi.fn().mockResolvedValue([]), saveLayout: vi.fn() }));
+vi.mock('d3-selection', () => ({ select: () => ({ call: () => {}, select: () => ({ attr: () => {} }) }) }));
+vi.mock('d3-zoom', () => ({
+  zoom: () => {
+    const obj: any = { scaleExtent: () => obj, on: () => obj, scaleBy: () => {} };
+    return obj;
+  },
+}));
+
+beforeAll(() => {
+  HTMLCanvasElement.prototype.getContext = () => ({
+    measureText: () => ({ width: 100 }),
+  }) as any;
+});
+
+const mockedUseItems = useItems as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockedUseItems.mockReset();
+});
+
+describe('IA badge rendering', () => {
+  it('shows IA badge in BacklogTable', () => {
+    mockedUseItems.mockReturnValue({
+      data: [{ id: 1, title: 'Table Item', type: 'Epic', generated_by_ai: true }],
+      isLoading: false,
+      error: null,
+    });
+    render(<BacklogTable projectId={1} onEdit={() => {}} />);
+    expect(screen.getByText('IA')).toBeInTheDocument();
+  });
+
+  it('shows IA badge in ItemTree', () => {
+    mockedUseItems.mockReturnValue({
+      tree: [{ id: 2, title: 'Tree Item', type: 'Epic', generated_by_ai: true, children: [] }],
+      isLoading: false,
+      error: null,
+    });
+    render(<ItemTree projectId={1} onEdit={() => {}} />);
+    expect(screen.getByText('IA')).toBeInTheDocument();
+  });
+
+  it('shows IA badge in DiagramView', async () => {
+    mockedUseItems.mockReturnValue({
+      data: [{ id: 3, title: 'Node', type: 'Epic', parent_id: null, generated_by_ai: true }],
+      isLoading: false,
+      error: null,
+    });
+    render(<DiagramView projectId={1} onEdit={() => {}} />);
+    await screen.findByText('Node');
+    expect(screen.getByText('IA')).toBeInTheDocument();
+  });
+
+  it('hides IA badge for non-AI items in DiagramView', async () => {
+    mockedUseItems.mockReturnValue({
+      data: [{ id: 4, title: 'Clean', type: 'Epic', parent_id: null }],
+      isLoading: false,
+      error: null,
+    });
+    render(<DiagramView projectId={1} onEdit={() => {}} />);
+    await screen.findByText('Clean');
+    expect(screen.queryByText('IA')).toBeNull();
+  });
+
+  it('clears generated_by_ai on save in ItemDialog', async () => {
+    mockedUseItems.mockReturnValue({ data: [], isLoading: false, error: null });
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const item = {
+      id: 5,
+      title: 'AI Item',
+      type: 'Epic',
+      project_id: 1,
+      parent_id: null,
+      description: null,
+      generated_by_ai: true,
+    } as any;
+    render(
+      <ItemDialog isOpen={true} onClose={() => {}} item={item} projectId={1} onSave={onSave} />
+    );
+    fireEvent.click(screen.getByText('Valider'));
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ generated_by_ai: false }))
+    );
+  });
+});
+

--- a/frontend/src/components/__tests__/BacklogTitleClick.test.tsx
+++ b/frontend/src/components/__tests__/BacklogTitleClick.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { ItemTree } from '../ItemTree';
+import { BacklogTable } from '../BacklogTable';
+import { DiagramView } from '../backlog/DiagramView';
+import { useItems } from '@/lib/hooks';
+
+vi.mock('@/lib/hooks', () => ({ useItems: vi.fn() }));
+vi.mock('@/components/backlog/useAutoFit', () => ({ useAutoFit: () => () => {} }));
+vi.mock('@/lib/layout', () => ({ getLayout: vi.fn().mockResolvedValue([]), saveLayout: vi.fn() }));
+vi.mock('d3-selection', () => ({ select: () => ({ call: () => {}, select: () => ({ attr: () => {} }) }) }));
+vi.mock('d3-zoom', () => ({
+  zoom: () => {
+    const obj: any = {
+      scaleExtent: () => obj,
+      on: () => obj,
+      scaleBy: () => {},
+    };
+    return obj;
+  },
+}));
+
+// provide canvas measureText
+beforeAll(() => {
+  HTMLCanvasElement.prototype.getContext = () => ({
+    measureText: () => ({ width: 100 }),
+  }) as any;
+});
+
+const mockedUseItems = useItems as unknown as ReturnType<typeof vi.fn>;
+
+describe('Backlog title click behavior', () => {
+  it('ItemTree - title click calls onEdit', () => {
+    mockedUseItems.mockReturnValue({
+      tree: [{ id: 1, title: 'Tree Item', type: 'Epic', children: [] }],
+      isLoading: false,
+      error: null,
+    });
+    const onEdit = vi.fn();
+    render(<ItemTree projectId={1} onEdit={onEdit} />);
+    fireEvent.click(screen.getByText('Tree Item'));
+    expect(onEdit).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }));
+  });
+
+  it('ItemTree - clicking container does not call onEdit', () => {
+    mockedUseItems.mockReturnValue({
+      tree: [{ id: 2, title: 'No Edit', type: 'Epic', children: [] }],
+      isLoading: false,
+      error: null,
+    });
+    const onEdit = vi.fn();
+    const { container } = render(<ItemTree projectId={1} onEdit={onEdit} />);
+    fireEvent.click(container.querySelector('[data-item-id="2"]')!);
+    expect(onEdit).not.toHaveBeenCalled();
+  });
+
+  it('BacklogTable - title click calls onEdit', () => {
+    mockedUseItems.mockReturnValue({
+      data: [{ id: 3, title: 'Table Item', type: 'Epic' }],
+      isLoading: false,
+      error: null,
+    });
+    const onEdit = vi.fn();
+    render(<BacklogTable projectId={1} onEdit={onEdit} />);
+    fireEvent.click(screen.getByText('Table Item'));
+    expect(onEdit).toHaveBeenCalledWith(expect.objectContaining({ id: 3 }));
+  });
+
+  it('BacklogTable - modifier button triggers onEdit once', () => {
+    mockedUseItems.mockReturnValue({
+      data: [{ id: 4, title: 'Btn Item', type: 'Epic' }],
+      isLoading: false,
+      error: null,
+    });
+    const onEdit = vi.fn();
+    render(<BacklogTable projectId={1} onEdit={onEdit} />);
+    fireEvent.click(screen.getByText('Modifier'));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it('DiagramView - title click calls onEdit', async () => {
+    mockedUseItems.mockReturnValue({
+      data: [{ id: 5, title: 'Diagram Item', type: 'Epic', parent_id: null }],
+      isLoading: false,
+      error: null,
+    });
+    const onEdit = vi.fn();
+    render(<DiagramView projectId={1} onEdit={onEdit} />);
+    const title = await screen.findByText('Diagram Item');
+    fireEvent.click(title);
+    expect(onEdit).toHaveBeenCalledWith(expect.objectContaining({ id: 5 }));
+  });
+
+  it('DiagramView - clicking node body does not call onEdit', async () => {
+    mockedUseItems.mockReturnValue({
+      data: [{ id: 6, title: 'No Title', type: 'Epic', parent_id: null }],
+      isLoading: false,
+      error: null,
+    });
+    const onEdit = vi.fn();
+    const { container } = render(<DiagramView projectId={1} onEdit={onEdit} />);
+    await screen.findByText('No Title');
+    fireEvent.click(container.querySelector('rect')!);
+    expect(onEdit).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/backlog/DiagramView.tsx
+++ b/frontend/src/components/backlog/DiagramView.tsx
@@ -13,6 +13,7 @@ import { Button } from '@/components/ui/button';
 
 interface DiagramViewProps {
   projectId: number | null;
+  onEdit: (item: BacklogItem) => void;
 }
 
 export interface NodeDatum {
@@ -46,7 +47,7 @@ const rankByType: Record<BacklogItem['type'], number> = {
   UC: 4,
 };
 
-export function DiagramView({ projectId }: DiagramViewProps) {
+export function DiagramView({ projectId, onEdit }: DiagramViewProps) {
   const { data: items } = useItems(projectId);
   const [nodes, setNodes] = useState<NodeDatum[]>([]);
   const [edges, setEdges] = useState<{ source: number; target: number }[]>([]);
@@ -244,7 +245,21 @@ export function DiagramView({ projectId }: DiagramViewProps) {
             >
               <rect width={n.width} height={n.height} rx={20} fill={typeColor[n.type]} />
               <title>{`${n.title} (${n.type})`}</title>
-              <text x={n.width / 2} y={n.height / 2} textAnchor="middle" dominantBaseline="middle" fill="#fff" fontSize="12">
+              <text
+                x={n.width / 2}
+                y={n.height / 2}
+                textAnchor="middle"
+                dominantBaseline="middle"
+                fill="#fff"
+                fontSize="12"
+                className="cursor-pointer"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  const item = items?.find(i => i.id === n.id);
+                  if (item) onEdit(item);
+                }}
+                onPointerDown={(e) => e.stopPropagation()}
+              >
                 {n.title.length > 20 ? n.title.slice(0, 20) + "…" : n.title}
               </text>
             </g>

--- a/frontend/src/components/backlog/DiagramView.tsx
+++ b/frontend/src/components/backlog/DiagramView.tsx
@@ -29,6 +29,7 @@ export interface NodeDatum {
   fx?: number;
   fy?: number;
   pinned?: boolean;
+  generated_by_ai?: boolean;
 }
 
 const typeColor: Record<string, string> = {
@@ -85,6 +86,7 @@ export function DiagramView({ projectId, onEdit }: DiagramViewProps) {
       height: 40,
       x: 0,
       y: 0,
+      generated_by_ai: item.generated_by_ai,
     }));
     const e = n
       .filter(nd => nd.parent_id !== null)
@@ -244,6 +246,24 @@ export function DiagramView({ projectId, onEdit }: DiagramViewProps) {
               onDoubleClick={() => setFocused(focused === n.id ? null : n.id)}
             >
               <rect width={n.width} height={n.height} rx={20} fill={typeColor[n.type]} />
+              {n.generated_by_ai && (
+                <g
+                  className="pointer-events-none"
+                  transform={`translate(${n.width - 18},4)`}
+                >
+                  <rect width={14} height={14} rx={3} fill="#8b5cf6" />
+                  <text
+                    x={7}
+                    y={7}
+                    textAnchor="middle"
+                    dominantBaseline="middle"
+                    fontSize="8"
+                    fill="#fff"
+                  >
+                    IA
+                  </text>
+                </g>
+              )}
               <title>{`${n.title} (${n.type})`}</title>
               <text
                 x={n.width / 2}


### PR DESCRIPTION
## Summary
- open item editor when backlog titles are clicked in tree, table and diagram views
- pass edit handler to diagram view and allow editing via title click
- add tests verifying backlog titles trigger editor

## Testing
- `npx vitest run src/components/__tests__/BacklogTitleClick.test.tsx`
- `pytest` *(fails: ValueError: "OpenAIEmbeddings" object...)*

------
https://chatgpt.com/codex/tasks/task_e_68bedfa4d27c833099d8af77ec457c66