### PR TITLE
Restrict tool exposure based on user intent

### DIFF
--- a/agents/tools.py
+++ b/agents/tools.py
@@ -62,6 +62,10 @@ class ListItemsArgs(BaseModel):
 
 class DeleteItemArgs(BaseModel):
     id: int
+    project_id: int
+    type: Literal["Epic", "Capability", "Feature", "US", "UC"]
+    reason: str
+    explicit_confirm: bool = False
 
 class MoveItemArgs(BaseModel):
     id: int

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -121,6 +121,7 @@ class ItemBase(BaseModel):
     type: Literal["Epic", "Capability", "Feature", "US", "UC"]
     project_id: int
     parent_id: int | None = None
+    is_deleted: bool = False
 
 # Extra fields per type
 # Base extras for creation (more flexible)

--- a/tests/test_delete_item_validation.py
+++ b/tests/test_delete_item_validation.py
@@ -1,0 +1,49 @@
+import pytest
+from agents.handlers import delete_item_tool, crud
+
+
+@pytest.mark.asyncio
+async def test_delete_item_rejects_generic_reason(monkeypatch):
+    monkeypatch.setattr(crud, "get_item", lambda _: object())
+    monkeypatch.setattr(crud, "delete_item", lambda _: 1)
+    res = await delete_item_tool({
+        "id": 1,
+        "project_id": 1,
+        "type": "US",
+        "reason": "cleanup",
+        "explicit_confirm": True,
+    })
+    assert not res["ok"]
+    assert res["error"] == "invalid_reason"
+
+
+@pytest.mark.asyncio
+async def test_delete_item_requires_confirmation(monkeypatch):
+    monkeypatch.setattr(crud, "get_item", lambda _: object())
+    monkeypatch.setattr(crud, "delete_item", lambda _: 1)
+    res = await delete_item_tool({
+        "id": 1,
+        "project_id": 1,
+        "type": "US",
+        "reason": "because",
+        "explicit_confirm": False,
+    })
+    assert not res["ok"]
+    assert res["error"] == "explicit_confirm_required"
+
+
+@pytest.mark.asyncio
+async def test_delete_item_logs_and_deletes(monkeypatch, caplog):
+    monkeypatch.setattr(crud, "get_item", lambda _: object())
+    monkeypatch.setattr(crud, "delete_item", lambda _: 1)
+    with caplog.at_level("INFO"):
+        res = await delete_item_tool({
+            "id": 1,
+            "project_id": 1,
+            "type": "US",
+            "reason": "remove",  # non-generic reason
+            "explicit_confirm": True,
+        })
+    assert res["ok"]
+    assert res["item_id"] == 1
+    assert any("'tool': 'delete_item'" in r.getMessage() for r in caplog.records)

--- a/tests/test_post_create_verification.py
+++ b/tests/test_post_create_verification.py
@@ -1,0 +1,99 @@
+import json
+import types
+import pytest
+from orchestrator import core_loop, crud, events
+from sqlmodel import create_engine
+from orchestrator.storage import db as ag_db
+
+
+class ToolCall(dict):
+    def __getattr__(self, item):
+        return self[item]
+
+
+class FakeLLM:
+    def __init__(self, responses):
+        self.responses = responses
+        self.calls = 0
+
+    def bind_tools(self, tools):
+        return self
+
+    def invoke(self, messages):
+        res = self.responses[self.calls]
+        self.calls += 1
+        return res
+
+
+def setup_agentic_db(monkeypatch, tmp_path):
+    db_file = tmp_path / "agentic.sqlite"
+    monkeypatch.setenv("AGENTIC_DB_URL", f"sqlite:///{db_file}")
+    ag_db.engine = create_engine(f"sqlite:///{db_file}")
+    ag_db.init_db()
+
+
+def test_verify_snapshot_success(monkeypatch):
+    class Item:
+        def dict(self):
+            return {"id": 1, "title": "t", "secret": "x"}
+
+    monkeypatch.setattr(crud, "get_item", lambda i: Item())
+    snap = core_loop._verify_and_snapshot_created_item(1)
+    assert snap == {"id": 1, "title": "t"}
+
+
+def test_verify_snapshot_failure(monkeypatch):
+    calls = {"n": 0}
+
+    def fake_get(i):
+        calls["n"] += 1
+        return None
+
+    monkeypatch.setattr(crud, "get_item", fake_get)
+    with pytest.raises(ValueError):
+        core_loop._verify_and_snapshot_created_item(1)
+    assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_run_chat_tools_attaches_snapshot(monkeypatch, tmp_path):
+    monkeypatch.setattr(crud, "DATABASE_URL", str(tmp_path / "db.sqlite"))
+    crud.init_db()
+    setup_agentic_db(monkeypatch, tmp_path)
+    run_id = "run-snap"
+    crud.create_run(run_id, "obj", 1)
+
+    class Item:
+        def dict(self):
+            return {"id": 1, "title": "Feat"}
+
+    monkeypatch.setattr(crud, "get_item", lambda i: Item())
+
+    async def fake_create(args):
+        return json.dumps({"ok": True, "item_id": 1})
+
+    schema = types.SimpleNamespace(__name__="S")
+    tool = types.SimpleNamespace(name="create_item", description="d", args_schema=schema, ainvoke=fake_create)
+    ai_call = ToolCall(name="create_item", args={}, id="0")
+    responses = [
+        types.SimpleNamespace(content="", tool_calls=[ai_call]),
+        types.SimpleNamespace(content="done", tool_calls=[]),
+    ]
+    monkeypatch.setattr(
+        core_loop,
+        "build_llm",
+        lambda provider, **k: FakeLLM(responses) if provider == "openai" else None,
+    )
+    monkeypatch.setattr(core_loop, "LC_TOOLS", [tool])
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(core_loop, "LLM_PROVIDER_ORDER", ["openai"])
+
+    captured = {}
+    monkeypatch.setattr(
+        events,
+        "emit_tool_result",
+        lambda run_id, name, result, tool_call_id, status="ok": captured.setdefault("r", result) or 0,
+    )
+
+    await core_loop.run_chat_tools("create something", 1, run_id)
+    assert captured["r"]["snapshot"]["id"] == 1

--- a/tests/test_soft_delete.py
+++ b/tests/test_soft_delete.py
@@ -1,0 +1,29 @@
+import pytest
+from orchestrator import crud
+from orchestrator.models import EpicCreate, ProjectCreate
+
+
+def _setup_db(monkeypatch, tmp_path):
+    db = tmp_path / 'db.sqlite'
+    monkeypatch.setattr(crud, 'DATABASE_URL', str(db))
+    crud.init_db()
+    crud.create_project(ProjectCreate(name='P', description=''))
+
+
+def test_soft_delete_marks_item_deleted(monkeypatch, tmp_path):
+    _setup_db(monkeypatch, tmp_path)
+    item = crud.create_item(EpicCreate(title='A', description='', project_id=1, parent_id=None))
+    assert not item.is_deleted
+    crud.delete_item(item.id)
+    deleted = crud.get_item(item.id)
+    assert deleted.is_deleted
+
+
+def test_list_items_excludes_deleted(monkeypatch, tmp_path):
+    _setup_db(monkeypatch, tmp_path)
+    a = crud.create_item(EpicCreate(title='A', description='', project_id=1, parent_id=None))
+    b = crud.create_item(EpicCreate(title='B', description='', project_id=1, parent_id=None))
+    crud.delete_item(a.id)
+    items = crud.get_items(1)
+    ids = {i.id for i in items}
+    assert a.id not in ids and b.id in ids

--- a/tests/test_tool_router.py
+++ b/tests/test_tool_router.py
@@ -1,0 +1,32 @@
+import types
+from orchestrator.core_loop import _filter_tools_by_objective
+
+
+def _tool(name: str):
+    return types.SimpleNamespace(
+        name=name,
+        description="",
+        args_schema=types.SimpleNamespace(__name__="S"),
+    )
+
+
+def test_create_intent_excludes_delete_item():
+    tools = [
+        _tool("create_item"),
+        _tool("delete_item"),
+        _tool("update_item"),
+        _tool("get_item"),
+        _tool("list_items"),
+        _tool("move_item"),
+    ]
+    filtered = _filter_tools_by_objective("Please create a new item", tools)
+    names = {t.name for t in filtered}
+    assert "delete_item" not in names
+    assert names == {"create_item", "update_item", "get_item", "list_items"}
+
+
+def test_delete_intent_includes_delete_item():
+    tools = [_tool("delete_item"), _tool("update_item")]
+    filtered = _filter_tools_by_objective("remove the old item", tools)
+    names = {t.name for t in filtered}
+    assert "delete_item" in names

--- a/tests/test_write_barrier.py
+++ b/tests/test_write_barrier.py
@@ -1,0 +1,113 @@
+import json
+import types
+import pytest
+
+from orchestrator import core_loop, crud
+from orchestrator.storage import db as ag_db
+from sqlmodel import create_engine
+
+class ToolCall(dict):
+    def __getattr__(self, item):
+        return self[item]
+
+class FakeLLM:
+    def __init__(self, responses):
+        self.responses = responses
+        self.calls = 0
+    def bind_tools(self, tools):
+        return self
+    def invoke(self, messages):
+        res = self.responses[self.calls]
+        self.calls += 1
+        return res
+
+async def _run_flow(monkeypatch, tmp_path, responses, delete_calls):
+    # stub tools
+    async def fake_create(args):
+        return json.dumps({"ok": True, "item_id": 1})
+    async def fake_delete(args):
+        delete_calls.append(args)
+        return json.dumps({"ok": True, "item_id": args["id"]})
+    schema = types.SimpleNamespace(__name__="S")
+    create_tool = types.SimpleNamespace(name="create_item", description="d", args_schema=schema, ainvoke=fake_create)
+    delete_tool = types.SimpleNamespace(name="delete_item", description="d", args_schema=schema, ainvoke=fake_delete)
+    monkeypatch.setattr(core_loop, "LC_TOOLS", [create_tool, delete_tool])
+
+    # fake llm provider
+    monkeypatch.setattr(core_loop, "build_llm", lambda provider, **k: FakeLLM(responses) if provider == "openai" else None)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(core_loop, "LLM_PROVIDER_ORDER", ["openai"])
+
+    # databases
+    monkeypatch.setattr(crud, "DATABASE_URL", str(tmp_path / "db.sqlite"))
+    crud.init_db()
+    db_file = tmp_path / "agentic.sqlite"
+    monkeypatch.setenv("AGENTIC_DB_URL", f"sqlite:///{db_file}")
+    ag_db.engine = create_engine(f"sqlite:///{db_file}")
+    ag_db.init_db()
+
+    class Item:
+        def dict(self):
+            return {"id": 1, "title": "t"}
+
+    monkeypatch.setattr(crud, "get_item", lambda i: Item())
+
+    # mute streams/events
+    monkeypatch.setattr(core_loop.stream, "publish", lambda *a, **k: None)
+    monkeypatch.setattr(core_loop.stream, "close", lambda *a, **k: None)
+    monkeypatch.setattr(core_loop.stream, "discard", lambda *a, **k: None)
+    monkeypatch.setattr(core_loop.events, "emit_status_update", lambda *a, **k: None)
+    monkeypatch.setattr(core_loop.events, "emit_tool_call", lambda *a, **k: None)
+    monkeypatch.setattr(core_loop.events, "emit_tool_result", lambda *a, **k: None)
+    monkeypatch.setattr(core_loop.events, "emit_assistant_answer", lambda *a, **k: None)
+    monkeypatch.setattr(core_loop.events, "cleanup_run", lambda *a, **k: None)
+
+    run_id = "r1"
+    crud.create_run(run_id, "delete", 1)
+    await core_loop.run_chat_tools("delete", 1, run_id)
+
+@pytest.mark.asyncio
+async def test_delete_blocked_without_confirmation(monkeypatch, tmp_path, caplog):
+    m_create = types.SimpleNamespace(content="", tool_calls=[ToolCall(name="create_item", args={"type":"US","title":"t","project_id":1}, id="0")])
+    m_delete = types.SimpleNamespace(
+        content="",
+        tool_calls=[
+            ToolCall(
+                name="delete_item",
+                args={"id": 1, "project_id": 1, "type": "US", "reason": "tmp"},
+                id="1",
+            )
+        ],
+    )
+    m_done = types.SimpleNamespace(content="done", tool_calls=[])
+    responses = [m_create, m_delete, m_done]
+    delete_calls = []
+    with caplog.at_level("WARNING"):
+        await _run_flow(monkeypatch, tmp_path, responses, delete_calls)
+    assert not delete_calls
+    assert "blocked_by_write_barrier" in caplog.text
+
+@pytest.mark.asyncio
+async def test_delete_allowed_with_confirmation(monkeypatch, tmp_path):
+    m_create = types.SimpleNamespace(content="", tool_calls=[ToolCall(name="create_item", args={"type":"US","title":"t","project_id":1}, id="0")])
+    m_delete = types.SimpleNamespace(
+        content="",
+        tool_calls=[
+            ToolCall(
+                name="delete_item",
+                args={
+                    "id": 1,
+                    "project_id": 1,
+                    "type": "US",
+                    "reason": "tmp",
+                    "explicit_confirm": True,
+                },
+                id="1",
+            )
+        ],
+    )
+    m_done = types.SimpleNamespace(content="done", tool_calls=[])
+    responses = [m_create, m_delete, m_done]
+    delete_calls = []
+    await _run_flow(monkeypatch, tmp_path, responses, delete_calls)
+    assert delete_calls and delete_calls[0]["id"] == 1


### PR DESCRIPTION
## Summary
- add intent-based tool filter so creation requests only expose safe item tools and deletion intents can access delete_item
- guard delete_item with in-run write barrier requiring explicit confirmation
- enforce detailed delete_item schema with project/type/reason and explicit confirmation plus validation and structured logging
- verify create_item results by fetching the item server-side and attaching its snapshot to the timeline
- perform soft deletes by flipping is_deleted and filtering list queries
- sanitize tool-call events so augmented args (run_id/project_id) aren't sent to the frontend
- test deletion filtering, write barrier behavior, backend validation, post-create snapshot logic, soft delete semantics, and event sanitization

## Testing
- `pytest tests/test_soft_delete.py tests/test_write_barrier.py tests/test_tool_router.py tests/test_delete_item_validation.py tests/test_post_create_verification.py tests/test_run_chat_tools.py::test_run_chat_tools_injects_ids tests/test_run_chat_tools.py::test_run_chat_tools_sanitizes_tool_call_args -q`


------
https://chatgpt.com/codex/tasks/task_e_68beeeb415248330bb33bdb813cc56a7