### PR TITLE
Persist conversation history across refresh

### DIFF
--- a/frontend/src/components/history/ConversationHistory.test.tsx
+++ b/frontend/src/components/history/ConversationHistory.test.tsx
@@ -4,7 +4,8 @@ import { useHistory } from '@/store/useHistory';
 import type { ConversationTurn } from '@/types/history';
 
 describe('ConversationHistory', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await useHistory.persist.clearStorage();
     useHistory.setState({ turns: {}, orderDesc: [], promoted: {} });
   });
 

--- a/frontend/src/pages/AgentShell.tsx
+++ b/frontend/src/pages/AgentShell.tsx
@@ -33,6 +33,7 @@ export function AgentShell() {
     const rehydrateStores = async () => {
       await useRunsStore.persist.rehydrate();
       await useMessagesStore.persist.rehydrate();
+      await useHistory.persist.rehydrate();
       setIsHydrated(true);
     };
     rehydrateStores();

--- a/frontend/src/store/useHistory.test.ts
+++ b/frontend/src/store/useHistory.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { useHistory } from './useHistory';
 
 describe('useHistory store', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await useHistory.persist.clearStorage();
     useHistory.setState({ turns: {}, orderDesc: [], promoted: {} });
   });
 
@@ -29,5 +30,11 @@ describe('useHistory store', () => {
     const action = useHistory.getState().turns.t.actions[0];
     expect(action.status).toBe('succeeded');
     expect(action.durationMs).toBe(10);
+  });
+
+  it('persists turns to storage', () => {
+    useHistory.getState().createTurn('id1', 'hello');
+    const stored = window.localStorage.getItem('agent-history-storage');
+    expect(stored && JSON.parse(stored).state.turns.id1.userText).toBe('hello');
   });
 });

--- a/frontend/src/store/useHistory.ts
+++ b/frontend/src/store/useHistory.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 import type { ConversationTurn, AgentAction } from '@/types/history';
 import { hashText } from '@/lib/historyAdapter';
 
@@ -18,86 +19,97 @@ export type HistoryState = {
   finalizeTurn: (turnId: string, ok: boolean) => void;
 };
 
-export const useHistory = create<HistoryState>((set, get) => ({
-  turns: {},
-  orderDesc: [],
-  promoted: {},
-  createTurn: (tempId, userText) =>
-    set((s) => ({
-      turns: {
-        ...s.turns,
-        [tempId]: {
-          turnId: tempId,
-          createdAt: Date.now(),
-          userText,
-          actions: [],
-          phase: 'running',
-        },
-      },
-      orderDesc: [tempId, ...s.orderDesc],
-    })),
-  promoteTurn: (tempId, realId) =>
-    set((s) => {
-      const turn = s.turns[tempId];
-      if (!turn) return s;
-      const { [tempId]: _removed, ...rest } = s.turns;
-      return {
-        turns: { ...rest, [realId]: { ...turn, turnId: realId } },
-        orderDesc: s.orderDesc.map((id) => (id === tempId ? realId : id)),
-        promoted: { ...s.promoted, [tempId]: realId },
-      };
-    }),
-  appendAction: (turnId, action) =>
-    set((s) => {
-      const realId = s.promoted[turnId] || turnId;
-      const turn = s.turns[realId];
-      if (!turn) return s;
-      return {
-        turns: {
-          ...s.turns,
-          [realId]: {
-            ...turn,
-            actions: [...turn.actions, action].sort(
-              (a, b) => (a.startedAt ?? 0) - (b.startedAt ?? 0),
-            ),
+export const useHistory = create<HistoryState>()(
+  persist(
+    (set, get) => ({
+      turns: {},
+      orderDesc: [],
+      promoted: {},
+      createTurn: (tempId, userText) =>
+        set((s) => ({
+          turns: {
+            ...s.turns,
+            [tempId]: {
+              turnId: tempId,
+              createdAt: Date.now(),
+              userText,
+              actions: [],
+              phase: 'running',
+            },
           },
-        },
-      };
+          orderDesc: [tempId, ...s.orderDesc],
+        })),
+      promoteTurn: (tempId, realId) =>
+        set((s) => {
+          const turn = s.turns[tempId];
+          if (!turn) return s;
+          const { [tempId]: _removed, ...rest } = s.turns;
+          return {
+            turns: { ...rest, [realId]: { ...turn, turnId: realId } },
+            orderDesc: s.orderDesc.map((id) =>
+              id === tempId ? realId : id,
+            ),
+            promoted: { ...s.promoted, [tempId]: realId },
+          };
+        }),
+      appendAction: (turnId, action) =>
+        set((s) => {
+          const realId = s.promoted[turnId] || turnId;
+          const turn = s.turns[realId];
+          if (!turn) return s;
+          return {
+            turns: {
+              ...s.turns,
+              [realId]: {
+                ...turn,
+                actions: [...turn.actions, action].sort(
+                  (a, b) => (a.startedAt ?? 0) - (b.startedAt ?? 0),
+                ),
+              },
+            },
+          };
+        }),
+      patchAction: (turnId, actionId, patch) =>
+        set((s) => {
+          const realId = s.promoted[turnId] || turnId;
+          const turn = s.turns[realId];
+          if (!turn) return s;
+          const actions = turn.actions.map((a) =>
+            a.id === actionId ? { ...a, ...patch } : a,
+          );
+          return { turns: { ...s.turns, [realId]: { ...turn, actions } } };
+        }),
+      setAgentTextOnce: (turnId, text) =>
+        set((s) => {
+          const realId = s.promoted[turnId] || turnId;
+          const turn = s.turns[realId];
+          if (!turn) return s;
+          const h = hashText(text);
+          if (turn.lastSummaryHash === h) return s;
+          return {
+            turns: {
+              ...s.turns,
+              [realId]: { ...turn, agentText: text, lastSummaryHash: h },
+            },
+          };
+        }),
+      finalizeTurn: (turnId, ok) =>
+        set((s) => {
+          const realId = s.promoted[turnId] || turnId;
+          const turn = s.turns[realId];
+          if (!turn) return s;
+          return {
+            turns: {
+              ...s.turns,
+              [realId]: { ...turn, phase: ok ? 'completed' : 'failed' },
+            },
+          };
+        }),
     }),
-  patchAction: (turnId, actionId, patch) =>
-    set((s) => {
-      const realId = s.promoted[turnId] || turnId;
-      const turn = s.turns[realId];
-      if (!turn) return s;
-      const actions = turn.actions.map((a) =>
-        a.id === actionId ? { ...a, ...patch } : a,
-      );
-      return { turns: { ...s.turns, [realId]: { ...turn, actions } } };
-    }),
-  setAgentTextOnce: (turnId, text) =>
-    set((s) => {
-      const realId = s.promoted[turnId] || turnId;
-      const turn = s.turns[realId];
-      if (!turn) return s;
-      const h = hashText(text);
-      if (turn.lastSummaryHash === h) return s;
-      return {
-        turns: {
-          ...s.turns,
-          [realId]: { ...turn, agentText: text, lastSummaryHash: h },
-        },
-      };
-    }),
-  finalizeTurn: (turnId, ok) =>
-    set((s) => {
-      const realId = s.promoted[turnId] || turnId;
-      const turn = s.turns[realId];
-      if (!turn) return s;
-      return {
-        turns: {
-          ...s.turns,
-          [realId]: { ...turn, phase: ok ? 'completed' : 'failed' },
-        },
-      };
-    }),
-}));
+    {
+      name: 'agent-history-storage',
+      skipHydration: true,
+    },
+  ),
+);
+


### PR DESCRIPTION
## Summary
- persist conversation turns in local storage so logs survive page reloads
- rehydrate conversation history store on app start
- cover history store persistence with tests

## Testing
- `pytest` *(fails: ValueError: "OpenAIEmbeddings" object has no attribute "client"...)*
- `cd frontend && pnpm test` *(fails: ws not ready; missing providers; etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bf08f90b9c8330865cf0121f4ad543