### PR TITLE
feat: isolate conversation history by project

### DIFF
--- a/frontend/src/components/history/ConversationHistory.test.tsx
+++ b/frontend/src/components/history/ConversationHistory.test.tsx
@@ -10,7 +10,7 @@ describe('ConversationHistory', () => {
   });
 
   it('shows placeholder when empty', () => {
-    render(<ConversationHistory />);
+    render(<ConversationHistory projectId={1} />);
     expect(screen.getByText('No conversation yet')).toBeInTheDocument();
   });
 
@@ -19,6 +19,7 @@ describe('ConversationHistory', () => {
       turnId: 'a',
       createdAt: 1,
       userText: 'Old',
+      projectId: 1,
       actions: [],
       agentText: 'A',
       phase: 'completed',
@@ -27,6 +28,7 @@ describe('ConversationHistory', () => {
       turnId: 'b',
       createdAt: 2,
       userText: 'New',
+      projectId: 1,
       actions: [],
       agentText: 'B',
       phase: 'completed',
@@ -36,9 +38,36 @@ describe('ConversationHistory', () => {
       orderDesc: ['b', 'a'],
       promoted: {},
     });
-    render(<ConversationHistory />);
+    render(<ConversationHistory projectId={1} />);
     const cards = screen.getAllByTestId('turn-card');
     expect(cards[0]).toHaveTextContent('New');
     expect(cards[1]).toHaveTextContent('Old');
+  });
+
+  it('filters turns by project', () => {
+    const turnA: ConversationTurn = {
+      turnId: 'a',
+      createdAt: 1,
+      userText: 'Project1',
+      projectId: 1,
+      actions: [],
+      phase: 'completed',
+    };
+    const turnB: ConversationTurn = {
+      turnId: 'b',
+      createdAt: 2,
+      userText: 'Project2',
+      projectId: 2,
+      actions: [],
+      phase: 'completed',
+    };
+    useHistory.setState({
+      turns: { a: turnA, b: turnB },
+      orderDesc: ['b', 'a'],
+      promoted: {},
+    });
+    render(<ConversationHistory projectId={1} />);
+    expect(screen.getByText('Project1')).toBeInTheDocument();
+    expect(screen.queryByText('Project2')).toBeNull();
   });
 });

--- a/frontend/src/components/history/ConversationHistory.tsx
+++ b/frontend/src/components/history/ConversationHistory.tsx
@@ -1,14 +1,17 @@
 import { useHistory } from '@/store/useHistory';
 import { ConversationTurnCard } from './ConversationTurnCard';
 
-export default function ConversationHistory() {
+export default function ConversationHistory({ projectId }: { projectId?: number }) {
   const { orderDesc, turns } = useHistory();
-  if (!orderDesc.length) {
+  const ids = projectId
+    ? orderDesc.filter((id) => turns[id]?.projectId === projectId)
+    : orderDesc;
+  if (!ids.length) {
     return <div className="text-sm text-muted-foreground p-3">No conversation yet</div>;
   }
   return (
     <div className="flex flex-col gap-3">
-      {orderDesc.map((id) => (
+      {ids.map((id) => (
         <ConversationTurnCard key={id} turn={turns[id]} />
       ))}
     </div>

--- a/frontend/src/components/history/ConversationHistoryPanel.tsx
+++ b/frontend/src/components/history/ConversationHistoryPanel.tsx
@@ -1,5 +1,5 @@
-import { ConversationHistory } from './ConversationHistory';
+import ConversationHistory from './ConversationHistory';
 
-export function ConversationHistoryPanel() {
-  return <ConversationHistory />;
+export function ConversationHistoryPanel({ projectId }: { projectId?: number }) {
+  return <ConversationHistory projectId={projectId} />;
 }

--- a/frontend/src/pages/AgentShell.tsx
+++ b/frontend/src/pages/AgentShell.tsx
@@ -89,7 +89,7 @@ export function AgentShell() {
     }
 
     const tempRunId = safeId();
-    useHistory.getState().createTurn(tempRunId, objective);
+    useHistory.getState().createTurn(tempRunId, objective, currentProject.id);
 
     const userMessage: Message = {
       id: `user-${Date.now()}`,
@@ -189,7 +189,7 @@ export function AgentShell() {
             <TabsContent value="history" className="flex-1 m-0">
               <div className="p-2 flex flex-col gap-2">
                 <AgentActionsPanel runId={currentRunId} />
-                <ConversationHistory />
+                <ConversationHistory projectId={currentProject?.id} />
               </div>
             </TabsContent>
           </div>
@@ -227,7 +227,7 @@ export function AgentShell() {
 
         <div className="w-1/4 p-2 flex flex-col gap-2">
           <AgentActionsPanel runId={currentRunId} />
-          <ConversationHistory />
+          <ConversationHistory projectId={currentProject?.id} />
         </div>
       </div>
     </div>

--- a/frontend/src/store/useHistory.test.ts
+++ b/frontend/src/store/useHistory.test.ts
@@ -8,7 +8,7 @@ describe('useHistory store', () => {
   });
 
   it('promotes temp id to real id', () => {
-    useHistory.getState().createTurn('temp', 'hi');
+    useHistory.getState().createTurn('temp', 'hi', 1);
     useHistory.getState().promoteTurn('temp', 'real');
     const state = useHistory.getState();
     expect(state.turns.real).toBeDefined();
@@ -16,7 +16,7 @@ describe('useHistory store', () => {
   });
 
   it('dedupes agent text using hash', () => {
-    useHistory.getState().createTurn('t', 'hi');
+    useHistory.getState().createTurn('t', 'hi', 1);
     useHistory.getState().setAgentTextOnce('t', 'summary');
     const firstHash = useHistory.getState().turns.t.lastSummaryHash;
     useHistory.getState().setAgentTextOnce('t', 'summary');
@@ -24,7 +24,7 @@ describe('useHistory store', () => {
   });
 
   it('patches actions', () => {
-    useHistory.getState().createTurn('t', 'hi');
+    useHistory.getState().createTurn('t', 'hi', 1);
     useHistory.getState().appendAction('t', { id: 'a', label: 'A', status: 'running' });
     useHistory.getState().patchAction('t', 'a', { status: 'succeeded', durationMs: 10 });
     const action = useHistory.getState().turns.t.actions[0];
@@ -33,8 +33,10 @@ describe('useHistory store', () => {
   });
 
   it('persists turns to storage', () => {
-    useHistory.getState().createTurn('id1', 'hello');
+    useHistory.getState().createTurn('id1', 'hello', 1);
     const stored = window.localStorage.getItem('agent-history-storage');
-    expect(stored && JSON.parse(stored).state.turns.id1.userText).toBe('hello');
+    const parsed = stored && JSON.parse(stored).state.turns.id1;
+    expect(parsed.userText).toBe('hello');
+    expect(parsed.projectId).toBe(1);
   });
 });

--- a/frontend/src/store/useHistory.ts
+++ b/frontend/src/store/useHistory.ts
@@ -7,7 +7,7 @@ export type HistoryState = {
   turns: Record<string, ConversationTurn>;
   orderDesc: string[];
   promoted: Record<string, string>;
-  createTurn: (tempId: string, userText: string) => void;
+  createTurn: (tempId: string, userText: string, projectId: number) => void;
   promoteTurn: (tempId: string, realId: string) => void;
   appendAction: (turnId: string, action: AgentAction) => void;
   patchAction: (
@@ -25,7 +25,7 @@ export const useHistory = create<HistoryState>()(
       turns: {},
       orderDesc: [],
       promoted: {},
-      createTurn: (tempId, userText) =>
+      createTurn: (tempId, userText, projectId) =>
         set((s) => ({
           turns: {
             ...s.turns,
@@ -33,6 +33,7 @@ export const useHistory = create<HistoryState>()(
               turnId: tempId,
               createdAt: Date.now(),
               userText,
+              projectId,
               actions: [],
               phase: 'running',
             },

--- a/frontend/src/types/history.ts
+++ b/frontend/src/types/history.ts
@@ -38,6 +38,7 @@ export type ConversationTurn = {
   turnId: string;
   createdAt: number;
   userText: string;
+  projectId: number;
   actions: AgentAction[];
   agentText?: string;
   phase: "running" | "completed" | "failed";


### PR DESCRIPTION
## Summary
- include projectId on each conversation turn
- filter conversation history by project and pass current project from AgentShell
- cover history store and UI with project-aware tests

## Testing
- `cd frontend && pnpm test src/components/history/ConversationHistory.test.tsx src/store/useHistory.test.ts --run`

------
https://chatgpt.com/codex/tasks/task_e_68c03ac2253083308dbe238a9776887d