### PR TITLE
chore: centralize websocket URL builder

### DIFF
--- a/frontend/src/app/runs/RunDetail.test.tsx
+++ b/frontend/src/app/runs/RunDetail.test.tsx
@@ -2,15 +2,16 @@ import { render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 import RunDetail from './[run_id]/page';
 
-vi.mock('@/lib/ws', () => ({
-  connectWS: () => ({
-    send: vi.fn(),
-    close: vi.fn(),
-    onopen: null,
-    onmessage: null,
-    onerror: null,
-  }),
-}));
+class MockWebSocket {
+  send = vi.fn();
+  close = vi.fn();
+  onopen: ((...args: any[]) => void) | null = null;
+  onmessage: ((...args: any[]) => void) | null = null;
+  onerror: ((...args: any[]) => void) | null = null;
+  constructor(_url: string) {}
+}
+
+(global as any).WebSocket = MockWebSocket as any;
 
 vi.mock('next/link', () => ({
   default: ({ children, ...props }: any) => <a {...props}>{children}</a>,

--- a/frontend/src/app/runs/[run_id]/page.tsx
+++ b/frontend/src/app/runs/[run_id]/page.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import RunTimeline from "@/components/RunTimeline";
 import { http } from "@/lib/api";
-import { connectWS } from "@/lib/ws";
+import { getWSUrl } from "@/lib/ws";
 
 interface Run {
   run_id: string;
@@ -42,8 +42,8 @@ export default function RunDetail({ params }: { params: { run_id: string } }) {
     }
     load();
 
-    const ws = connectWS("/stream");
-    wsRef.current = ws;
+      const ws = new WebSocket(getWSUrl("/stream"));
+      wsRef.current = ws;
     ws.onopen = () => {
       ws.send(JSON.stringify({ run_id: params.run_id }));
     };

--- a/frontend/src/hooks/useAgentStream.test.ts
+++ b/frontend/src/hooks/useAgentStream.test.ts
@@ -22,13 +22,18 @@ class MockWebSocket {
 }
 
 (global as any).WebSocket = MockWebSocket as any;
+if (typeof window !== 'undefined') {
+  (window as any).WebSocket = MockWebSocket as any;
+}
 
 describe('useAgentStream on close', () => {
-  beforeEach(() => {
-    MockWebSocket.last = undefined;
-    useRunsStore.getState().clearRuns();
-    vi.resetAllMocks();
-  });
+beforeEach(() => {
+  MockWebSocket.last = undefined;
+  useRunsStore.getState().clearRuns();
+  vi.resetAllMocks();
+  process.env.NEXT_PUBLIC_WS_URL = 'ws://test';
+  return new Promise((r) => setTimeout(r, 350));
+});
 
   it('finalizes run with summary when backend is done', async () => {
     const tempId = 'temp1';

--- a/frontend/src/hooks/useAgentStream.ts
+++ b/frontend/src/hooks/useAgentStream.ts
@@ -5,6 +5,7 @@ import { toLabel } from "@/lib/historyAdapter";
 import { safeId } from "@/lib/safeId";
 import { http } from "@/lib/api";
 import { useAgentActionsStore } from "@/hooks/useAgentActions";
+import { getWSUrl } from "@/lib/ws";
 
 // Phases for a run lifecycle
 export type RunPhase =
@@ -133,8 +134,7 @@ export function useAgentStream(
     };
 
     const r = runRef.current;
-    const WS_URL =
-      process.env.NEXT_PUBLIC_WS_URL ?? "ws://192.168.1.93:8000/stream";
+    const WS_URL = getWSUrl("/stream");
 
     try {
       const ws = await openSocket(WS_URL, r.wsId!);

--- a/frontend/src/hooks/useConversationHistory.ts
+++ b/frontend/src/hooks/useConversationHistory.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import type { ConversationRun, RunEvent } from '@/types/events';
 import { safeId } from '@/lib/safeId';
+import { getWSUrl } from '@/lib/ws';
 
 export interface UseConversationHistoryOptions {
   autoRefresh?: boolean;
@@ -85,9 +86,8 @@ export function useConversationHistory(options: UseConversationHistoryOptions = 
       return; // Already subscribed
     }
 
-    try {
-      const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-      const ws = new WebSocket(`${protocol}//${window.location.host}/api/stream`);
+      try {
+        const ws = new WebSocket(getWSUrl('/api/stream'));
       
       ws.onopen = () => {
         ws.send(JSON.stringify({

--- a/frontend/src/hooks/useRunStream.ts
+++ b/frontend/src/hooks/useRunStream.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { getWSUrl } from '@/lib/ws';
 
 export type AgentStep = {
   id: string;
@@ -65,11 +66,6 @@ export function useRunStream(options: UseRunStreamOptions) {
   const manualClose = useRef(false);
   const seqRef = useRef<Record<string, number>>({});
   const reconnectTimer = useRef<number>();
-
-  const getWsUrl = () => {
-    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    return `${protocol}//${window.location.host}/stream`;
-  };
 
   const closeSocket = () => {
     if (wsRef.current) {
@@ -177,7 +173,7 @@ export function useRunStream(options: UseRunStreamOptions) {
   const openSocket = useCallback(() => {
     manualClose.current = false;
     closeSocket();
-    const ws = new WebSocket(getWsUrl());
+      const ws = new WebSocket(getWSUrl('/stream'));
     wsRef.current = ws;
     ws.onmessage = handleMessage;
     ws.onclose = () => {


### PR DESCRIPTION
## Summary
- centralize WebSocket URL logic with `getWSUrl`
- use helper across hooks and pages for proper ws/wss selection
- add tests covering override, protocol, and SSR fallback cases

## Testing
- `npm test src/lib/ws.test.ts src/app/runs/RunDetail.test.tsx src/hooks/useAgentStream.test.ts src/hooks/useRunStream.test.ts`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68c2734ca9b08330ab0aa138dbd2b2f1