### PR TITLE
feat: redesign login with shadcn

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.12",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
         version: 1.1.15(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-label':
+        specifier: ^2.1.7
+        version: 2.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-select':
         specifier: ^2.2.5
         version: 2.2.6(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1098,6 +1101,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-label@2.1.7':
+    resolution: {integrity: sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-popper@1.2.8':
@@ -5172,6 +5188,15 @@ snapshots:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.8
+
+  '@radix-ui/react-label@2.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
 
   '@radix-ui/react-popper@1.2.8(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:

--- a/frontend/src/app/login/__tests__/page.test.tsx
+++ b/frontend/src/app/login/__tests__/page.test.tsx
@@ -11,6 +11,7 @@ vi.mock('firebase/auth', () => ({
 
 import {
   signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
   signInWithPopup,
 } from 'firebase/auth';
 import LoginPage from '../page';
@@ -18,16 +19,17 @@ import LoginPage from '../page';
 describe('LoginPage', () => {
   beforeEach(() => {
     (signInWithEmailAndPassword as any).mockReset();
+    (createUserWithEmailAndPassword as any).mockReset();
     (signInWithPopup as any).mockReset();
   });
 
   it('signs in with email and password', async () => {
     signInWithEmailAndPassword.mockResolvedValue({});
     render(<LoginPage />);
-    fireEvent.change(screen.getByPlaceholderText('email'), {
+    fireEvent.change(screen.getByLabelText('Email'), {
       target: { value: 'a@b.com' },
     });
-    fireEvent.change(screen.getByPlaceholderText('password'), {
+    fireEvent.change(screen.getByLabelText('Password'), {
       target: { value: 'pwd' },
     });
     await act(async () => {
@@ -39,15 +41,54 @@ describe('LoginPage', () => {
   it('shows error when sign-in fails', async () => {
     signInWithEmailAndPassword.mockRejectedValue(new Error('nope'));
     render(<LoginPage />);
-    fireEvent.change(screen.getByPlaceholderText('email'), {
+    fireEvent.change(screen.getByLabelText('Email'), {
       target: { value: 'a@b.com' },
     });
-    fireEvent.change(screen.getByPlaceholderText('password'), {
+    fireEvent.change(screen.getByLabelText('Password'), {
       target: { value: 'pwd' },
     });
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
     });
     expect(await screen.findByText('nope')).toBeInTheDocument();
+  });
+
+  it('creates an account', async () => {
+    createUserWithEmailAndPassword.mockResolvedValue({});
+    render(<LoginPage />);
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'a@b.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'pwd' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+    });
+    expect(createUserWithEmailAndPassword).toHaveBeenCalledWith({}, 'a@b.com', 'pwd');
+  });
+
+  it('shows error when sign-up fails', async () => {
+    createUserWithEmailAndPassword.mockRejectedValue(new Error('signup bad'));
+    render(<LoginPage />);
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'a@b.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'pwd' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+    });
+    expect(await screen.findByText('signup bad')).toBeInTheDocument();
+  });
+
+  it('signs in with google', async () => {
+    signInWithPopup.mockResolvedValue({});
+    render(<LoginPage />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Continue with Google' }));
+    });
+    expect(signInWithPopup).toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import { useState } from "react";
 import { auth } from "@/lib/firebase";
 import {
@@ -8,63 +9,73 @@ import {
   signInWithPopup,
 } from "firebase/auth";
 
+// shadcn/ui
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
 export default function LoginPage() {
   const [email, setEmail] = useState("");
   const [pwd, setPwd] = useState("");
+  const [loading, setLoading] = useState<"none"|"signin"|"signup"|"google">("none");
   const [err, setErr] = useState<string | null>(null);
 
   async function doSignIn() {
-    setErr(null);
-    try {
-      await signInWithEmailAndPassword(auth, email, pwd);
-      window.location.href = "/";
-    } catch (e: any) {
-      setErr(e.message ?? "Sign in failed");
-    }
+    setErr(null); setLoading("signin");
+    try { await signInWithEmailAndPassword(auth, email, pwd); window.location.href = "/"; }
+    catch (e: any) { setErr(e.message ?? "Sign in failed"); }
+    finally { setLoading("none"); }
   }
 
   async function doSignUp() {
-    setErr(null);
-    try {
-      await createUserWithEmailAndPassword(auth, email, pwd);
-      window.location.href = "/";
-    } catch (e: any) {
-      setErr(e.message ?? "Sign up failed");
-    }
+    setErr(null); setLoading("signup");
+    try { await createUserWithEmailAndPassword(auth, email, pwd); window.location.href = "/"; }
+    catch (e: any) { setErr(e.message ?? "Sign up failed"); }
+    finally { setLoading("none"); }
   }
 
   async function doGoogle() {
-    setErr(null);
-    try {
-      await signInWithPopup(auth, new GoogleAuthProvider());
-      window.location.href = "/";
-    } catch (e: any) {
-      setErr(e.message ?? "Google sign-in failed");
-    }
+    setErr(null); setLoading("google");
+    try { await signInWithPopup(auth, new GoogleAuthProvider()); window.location.href = "/"; }
+    catch (e: any) { setErr(e.message ?? "Google sign-in failed"); }
+    finally { setLoading("none"); }
   }
 
   return (
-    <div style={{ maxWidth: 420, margin: "48px auto", fontFamily: "system-ui" }}>
-      <h1>Sign in</h1>
-      <input
-        placeholder="email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        style={{ width: "100%", margin: "8px 0", padding: 8 }}
-      />
-      <input
-        placeholder="password"
-        type="password"
-        value={pwd}
-        onChange={(e) => setPwd(e.target.value)}
-        style={{ width: "100%", margin: "8px 0", padding: 8 }}
-      />
-      {err && <div style={{ color: "crimson" }}>{err}</div>}
-      <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
-        <button onClick={doSignIn}>Sign in</button>
-        <button onClick={doSignUp}>Create account</button>
-        <button onClick={doGoogle}>Continue with Google</button>
-      </div>
+    <div className="min-h-dvh flex items-center justify-center bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-slate-50 to-slate-100 p-6">
+      <Card className="w-full max-w-md shadow-lg">
+        <CardHeader>
+          <CardTitle className="text-2xl">Sign in</CardTitle>
+          <CardDescription>Access your Agent 4 BA workspace</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-2">
+            <Label htmlFor="email">Email</Label>
+            <Input id="email" type="email" placeholder="you@example.com" value={email} onChange={(e)=>setEmail(e.target.value)} />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="password">Password</Label>
+            <Input id="password" type="password" placeholder="••••••••" value={pwd} onChange={(e)=>setPwd(e.target.value)} />
+          </div>
+          {err && <p className="text-sm text-red-600">{err}</p>}
+        </CardContent>
+        <CardFooter className="flex flex-col gap-2">
+          <Button className="w-full" onClick={doSignIn} disabled={loading!=="none"}>
+            {loading==="signin" ? "Signing in..." : "Sign in"}
+          </Button>
+          <Button variant="secondary" className="w-full" onClick={doSignUp} disabled={loading!=="none"}>
+            {loading==="signup" ? "Creating..." : "Create account"}
+          </Button>
+          <div className="relative my-1 w-full text-center text-xs text-slate-500">
+            <span className="bg-white px-2 relative z-10">or</span>
+            <div className="absolute inset-x-0 top-1/2 -translate-y-1/2 border-t"></div>
+          </div>
+          <Button variant="outline" className="w-full" onClick={doGoogle} disabled={loading!=="none"}>
+            {loading==="google" ? "Connecting..." : "Continue with Google"}
+          </Button>
+        </CardFooter>
+      </Card>
     </div>
   );
 }

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { cn } from "@/lib/utils";
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(
+      "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+      className
+    )}
+    {...props}
+  />
+));
+Label.displayName = LabelPrimitive.Root.displayName;
+
+export { Label };


### PR DESCRIPTION
## Summary
- replace barebones login page with shadcn card layout and loading states
- add shadcn label component and dependency
- extend login tests for signup and google auth flows

## Testing
- `npm run lint` *(fails: numerous existing lint errors across repo)*
- `npm test` *(fails: existing tests fail with auth and websocket errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c42db316d48330a85350f0beb405f1