### PR TITLE
Handle unauthorized project fetches gracefully

### DIFF
--- a/frontend/src/components/project/ProjectPanel.tsx
+++ b/frontend/src/components/project/ProjectPanel.tsx
@@ -171,7 +171,7 @@ export function ProjectPanel() {
             <SelectValue placeholder="Select a project" />
           </SelectTrigger>
           <SelectContent>
-            {projects.map((project) => (
+            {Array.isArray(projects) && projects.map((project) => (
               <SelectItem key={project.id} value={project.id.toString()}>
                 <div>
                   <div className="font-medium">{project.name}</div>

--- a/frontend/src/context/ProjectContext.test.tsx
+++ b/frontend/src/context/ProjectContext.test.tsx
@@ -50,7 +50,7 @@ describe("ProjectProvider auth gating", () => {
       cb(authMock.currentUser);
       return () => {};
     });
-    apiFetchMock.mockResolvedValue({ json: async () => [{ id: 1, name: "P1" }] });
+    apiFetchMock.mockResolvedValue({ ok: true, json: async () => [{ id: 1, name: "P1" }] });
 
     const { getByTestId } = render(
       <ProjectProvider>
@@ -68,7 +68,7 @@ describe("ProjectProvider auth gating", () => {
       cb = callback;
       return () => {};
     });
-    apiFetchMock.mockResolvedValue({ json: async () => [{ id: 1, name: "P1" }] });
+    apiFetchMock.mockResolvedValue({ ok: true, json: async () => [{ id: 1, name: "P1" }] });
 
     const { getByTestId } = render(
       <ProjectProvider>
@@ -85,5 +85,41 @@ describe("ProjectProvider auth gating", () => {
     cb(null);
     await waitFor(() => expect(getByTestId("count").textContent).toBe("0"));
     expect(apiFetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("sets empty projects when response not ok", async () => {
+    onAuthStateChangedMock.mockImplementation((authArg, cb) => {
+      authMock.currentUser = { uid: "u1" } as any;
+      cb(authMock.currentUser);
+      return () => {};
+    });
+    apiFetchMock.mockResolvedValue({ ok: false, json: async () => ({ detail: "unauthorized" }) });
+
+    const { getByTestId } = render(
+      <ProjectProvider>
+        <TestChild />
+      </ProjectProvider>
+    );
+
+    await waitFor(() => expect(apiFetchMock).toHaveBeenCalled());
+    await waitFor(() => expect(getByTestId("count").textContent).toBe("0"));
+  });
+
+  it("sets empty projects when JSON is not array", async () => {
+    onAuthStateChangedMock.mockImplementation((authArg, cb) => {
+      authMock.currentUser = { uid: "u1" } as any;
+      cb(authMock.currentUser);
+      return () => {};
+    });
+    apiFetchMock.mockResolvedValue({ ok: true, json: async () => ({ detail: "oops" }) });
+
+    const { getByTestId } = render(
+      <ProjectProvider>
+        <TestChild />
+      </ProjectProvider>
+    );
+
+    await waitFor(() => expect(apiFetchMock).toHaveBeenCalled());
+    await waitFor(() => expect(getByTestId("count").textContent).toBe("0"));
   });
 });

--- a/frontend/src/context/ProjectContext.tsx
+++ b/frontend/src/context/ProjectContext.tsx
@@ -27,15 +27,35 @@ export const ProjectProvider = ({ children }: { children: ReactNode }) => {
     setIsLoading(true);
     try {
       const response = await apiFetch(`/projects`);
-      const data = await response.json();
-      setProjects(data);
-      if (data.length > 0 && !currentProject) {
-        setCurrentProject(data[0]); // Sélectionner le premier par défaut si aucun n'est sélectionné
-      } else if (data.length === 0) {
+      if (!response.ok) {
+        setProjects([]);
+        setCurrentProject(null);
+        return;
+      }
+      let data: unknown = null;
+      try {
+        data = await response.json();
+      } catch {
+        data = null;
+      }
+      const normalized: Project[] =
+        Array.isArray(data)
+          ? (data as Project[])
+          : Array.isArray((data as any)?.projects)
+            ? (data as any).projects
+            : Array.isArray((data as any)?.items)
+              ? (data as any).items
+              : [];
+      setProjects(normalized);
+      if (normalized.length > 0 && !currentProject) {
+        setCurrentProject(normalized[0]); // Select first by default
+      } else if (normalized.length === 0) {
         setCurrentProject(null);
       }
     } catch (error) {
       console.error("Failed to fetch projects:", error);
+      setProjects([]);
+      setCurrentProject(null);
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
## Summary
- normalize project fetch results to an array and reset selection on errors
- guard ProjectPanel rendering against non-array project lists
- test auth gating and error handling for project fetches

## Testing
- `pnpm test` *(fails: Firebase invalid-api-key, missing modules, etc.)*
- `pnpm lint` *(fails: extensive lint errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c4387aa5188330a7bc8483205e9725