### PR TITLE
Auto-provision users on first /projects access

### DIFF
--- a/backend/app/routes/projects.py
+++ b/backend/app/routes/projects.py
@@ -1,9 +1,15 @@
 from fastapi import APIRouter, Depends
+from typing import Any, List
 from backend.app.security import get_current_user
 from orchestrator import crud
 
 router = APIRouter(prefix="/projects", tags=["projects"])
 
-@router.get("")
+
+@router.get("", response_model=List[Any])
 def list_projects(user=Depends(get_current_user)):
-    return crud.get_projects_for_user(user["uid"]) if hasattr(crud, "get_projects_for_user") else crud.get_projects()
+    if hasattr(crud, "get_projects_for_user"):
+        projects = crud.get_projects_for_user(user["uid"])
+    else:
+        projects = crud.get_projects()
+    return projects or []

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -1,18 +1,32 @@
+import os
 from fastapi import Depends, HTTPException
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from firebase_admin import auth as fb_auth
+from orchestrator import crud
+
+ADMIN_EMAILS = {
+    e.strip().lower()
+    for e in os.getenv("ADMIN_EMAILS", "").split(",")
+    if e.strip()
+}
 
 http_bearer = HTTPBearer(auto_error=False)
+
 
 def get_current_user(creds: HTTPAuthorizationCredentials = Depends(http_bearer)):
     if creds is None:
         raise HTTPException(status_code=401, detail="Authentication required")
     try:
         t = fb_auth.verify_id_token(creds.credentials)
-        return {
-            "uid": t["uid"],
-            "email": t.get("email"),
-            "email_verified": t.get("email_verified", False),
-        }
     except Exception as e:  # pragma: no cover - verification details handled by Firebase
         raise HTTPException(status_code=401, detail=f"Invalid token: {e}")
+    uid = t["uid"]
+    email = (t.get("email") or "").lower()
+    u = crud.get_user_by_uid(uid)
+    if not u:
+        crud.create_user(uid=uid, email=email, is_admin=(email in ADMIN_EMAILS))
+    return {
+        "uid": uid,
+        "email": email,
+        "email_verified": t.get("email_verified", False),
+    }

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -13,6 +13,12 @@ class ProjectCreate(BaseModel):
     description: str | None = None
 
 
+class User(BaseModel):
+    uid: str
+    email: str | None = None
+    is_admin: bool = False
+
+
 class Document(BaseModel):
     """File uploaded to a project."""
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,15 +5,19 @@ from fastapi.security import HTTPAuthorizationCredentials
 from backend.app.security import get_current_user
 
 
-def test_get_current_user_valid(monkeypatch):
+def test_get_current_user_existing_user(monkeypatch):
     def fake_verify(token):
         assert token == 'abc'
         return {'uid': 'u1', 'email': 'e@example.com', 'email_verified': True}
 
     monkeypatch.setattr('backend.app.security.fb_auth.verify_id_token', fake_verify)
+    monkeypatch.setattr('orchestrator.crud.get_user_by_uid', lambda uid: {'uid': uid})
+    created = []
+    monkeypatch.setattr('orchestrator.crud.create_user', lambda **kw: created.append(kw))
     creds = HTTPAuthorizationCredentials(scheme='Bearer', credentials='abc')
     user = get_current_user(creds)
     assert user == {'uid': 'u1', 'email': 'e@example.com', 'email_verified': True}
+    assert created == []
 
 
 def test_get_current_user_missing_token():
@@ -31,6 +35,27 @@ def test_get_current_user_invalid(monkeypatch):
         get_current_user(creds)
 
 
+def test_get_current_user_auto_provisions_admin(monkeypatch):
+    def fake_verify(token):
+        assert token == 'abc'
+        return {'uid': 'u1', 'email': 'admin@example.com'}
+
+    monkeypatch.setattr('backend.app.security.fb_auth.verify_id_token', fake_verify)
+    monkeypatch.setattr('orchestrator.crud.get_user_by_uid', lambda uid: None)
+    created = {}
+
+    def fake_create_user(uid, email, is_admin):
+        created.update({'uid': uid, 'email': email, 'is_admin': is_admin})
+        return created
+
+    monkeypatch.setattr('orchestrator.crud.create_user', fake_create_user)
+    monkeypatch.setattr('backend.app.security.ADMIN_EMAILS', {'admin@example.com'})
+    creds = HTTPAuthorizationCredentials(scheme='Bearer', credentials='abc')
+    user = get_current_user(creds)
+    assert user['uid'] == 'u1'
+    assert created == {'uid': 'u1', 'email': 'admin@example.com', 'is_admin': True}
+
+
 from fastapi.testclient import TestClient
 from api.main import app
 
@@ -44,13 +69,34 @@ def test_projects_route_requires_auth():
 def test_projects_route_returns_projects(monkeypatch):
     def fake_verify(token):
         assert token == "good"
-        return {"uid": "u1"}
+        return {"uid": "u1", 'email': 'e@example.com'}
 
     monkeypatch.setattr(
         "backend.app.security.fb_auth.verify_id_token", fake_verify
     )
+    monkeypatch.setattr('orchestrator.crud.get_user_by_uid', lambda uid: {'uid': uid})
+    monkeypatch.setattr('orchestrator.crud.create_user', lambda uid, email, is_admin: None)
     monkeypatch.setattr("orchestrator.crud.get_projects", lambda: [{"id": 1}])
     client = TestClient(app)
     r = client.get("/projects", headers={"Authorization": "Bearer good"})
     assert r.status_code == 200
     assert r.json() == [{"id": 1}]
+
+
+def test_projects_route_returns_empty_list(monkeypatch):
+    def fake_verify(token):
+        assert token == "good"
+        return {"uid": "u1", 'email': 'e@example.com'}
+
+    monkeypatch.setattr(
+        "backend.app.security.fb_auth.verify_id_token", fake_verify
+    )
+    monkeypatch.setattr('orchestrator.crud.get_user_by_uid', lambda uid: None)
+    created = {}
+    monkeypatch.setattr('orchestrator.crud.create_user', lambda uid, email, is_admin: created.update({'uid': uid}))
+    monkeypatch.setattr("orchestrator.crud.get_projects", lambda: [])
+    client = TestClient(app)
+    r = client.get("/projects", headers={"Authorization": "Bearer good"})
+    assert r.status_code == 200
+    assert r.json() == []
+    assert created["uid"] == "u1"


### PR DESCRIPTION
## Summary
- Add user auto-provisioning with admin flag based on `ADMIN_EMAILS`
- Ensure `/projects` always returns a list and works for new users
- Introduce user table and CRUD helpers
- Cover new behavior with auth and project route tests

## Testing
- `pytest` *(failed: process killed around 73%)*
- `pytest tests/test_auth.py`


------
https://chatgpt.com/codex/tasks/task_e_68c43a1e03588330ad4ad05b5eb357a9