### PR TITLE
Add conversation memory manager

### DIFF
--- a/orchestrator/conversation_memory.py
+++ b/orchestrator/conversation_memory.py
@@ -1,0 +1,62 @@
+"""Conversation memory management utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Sequence
+
+
+@dataclass(frozen=True)
+class ChatMessage:
+    """Container for an individual chat message."""
+
+    role: str
+    content: str
+
+    def to_dict(self) -> dict[str, str]:
+        """Convert the message to a serialisable dictionary."""
+        return {"role": self.role, "content": self.content}
+
+
+class ConversationMemory:
+    """Manage chat history and an optional summary for a conversation."""
+
+    def __init__(self) -> None:
+        self._messages: List[ChatMessage] = []
+        self.summary: str = ""
+
+    def add_message(self, role: str, content: str) -> None:
+        """Add a validated chat message to the conversation history."""
+        if not isinstance(role, str) or not role.strip():
+            raise ValueError("role must be a non-empty string")
+        if not isinstance(content, str):
+            raise ValueError("content must be a string")
+
+        self._messages.append(ChatMessage(role=role.strip(), content=content))
+
+    def update_summary(self, summary: str) -> None:
+        """Replace the stored conversation summary."""
+        if not isinstance(summary, str):
+            raise ValueError("summary must be a string")
+        self.summary = summary.strip()
+
+    def get_recent_messages(self, n: int = 5) -> List[dict[str, str]]:
+        """Return the latest messages, optionally prefixed with the summary."""
+        if not isinstance(n, int) or n <= 0:
+            raise ValueError("n must be a positive integer")
+
+        recent: Sequence[ChatMessage] = self._messages[-n:]
+        recent_as_dicts = [message.to_dict() for message in recent]
+
+        if self.summary:
+            summary_message = {
+                "role": "system",
+                "content": f"Summary of previous conversation: {self.summary}",
+            }
+            return [summary_message, *recent_as_dicts]
+
+        return recent_as_dicts.copy()
+
+    @property
+    def messages(self) -> List[dict[str, str]]:
+        """Expose a copy of the entire message history."""
+        return [message.to_dict() for message in self._messages]

--- a/tests/test_conversation_memory.py
+++ b/tests/test_conversation_memory.py
@@ -1,0 +1,62 @@
+import pytest
+
+from orchestrator.conversation_memory import ConversationMemory
+
+
+@pytest.fixture
+def memory():
+    return ConversationMemory()
+
+
+class TestAddMessage:
+    def test_adds_message_to_history(self, memory):
+        memory.add_message("user", "Hello")
+
+        assert memory.messages == [{"role": "user", "content": "Hello"}]
+
+    @pytest.mark.parametrize("role", ["", "   ", 123])
+    def test_rejects_invalid_role(self, memory, role):
+        with pytest.raises(ValueError):
+            memory.add_message(role, "content")
+
+    def test_rejects_non_string_content(self, memory):
+        with pytest.raises(ValueError):
+            memory.add_message("user", 42)
+
+
+class TestUpdateSummary:
+    def test_updates_summary(self, memory):
+        memory.update_summary("Past details")
+
+        assert memory.summary == "Past details"
+
+    def test_update_summary_strips_whitespace(self, memory):
+        memory.update_summary("  trimmed  ")
+
+        assert memory.summary == "trimmed"
+
+
+class TestGetRecentMessages:
+    def test_returns_recent_messages_up_to_n(self, memory):
+        for index in range(6):
+            memory.add_message("user", f"msg {index}")
+
+        recent = memory.get_recent_messages(3)
+
+        assert [m["content"] for m in recent] == ["msg 3", "msg 4", "msg 5"]
+
+    def test_includes_summary_when_available(self, memory):
+        memory.add_message("user", "Hi")
+        memory.update_summary("Earlier context")
+
+        result = memory.get_recent_messages(1)
+
+        assert result[0] == {
+            "role": "system",
+            "content": "Summary of previous conversation: Earlier context",
+        }
+        assert result[1] == {"role": "user", "content": "Hi"}
+
+    def test_rejects_non_positive_n(self, memory):
+        with pytest.raises(ValueError):
+            memory.get_recent_messages(0)


### PR DESCRIPTION
## Summary
- add a reusable ConversationMemory helper to manage chat transcripts and summary context
- provide validation and conversion helpers around stored messages
- cover the new memory helper with positive and edge case unit tests

## Testing
- `poetry run pytest tests/test_conversation_memory.py`


------
https://chatgpt.com/codex/tasks/task_e_68c8e64c6b1483308c4619a918ec18b9